### PR TITLE
[codex] Clarify pixel value component order

### DIFF
--- a/Viewer/ViewerView.cpp
+++ b/Viewer/ViewerView.cpp
@@ -834,8 +834,8 @@ void CViewerView::DrawPixelValueMode(CDC *pDC)
 	modeFont.CreateFontIndirect(&lf);
 	CFont *prevFont = pDC->SelectObject(&modeFont);
 
-	CString mode = mShowSourceYuv ? _T("PIXEL: YUV SOURCE") :
-		_T("PIXEL: RGB DISPLAY");
+	CString mode = mShowSourceYuv ? _T("PIXEL: Y/U/V SOURCE") :
+		_T("PIXEL: R/G/B DISPLAY");
 	CRect refRect;
 	pDC->DrawText(mode, -1, refRect, DT_SINGLELINE | DT_CALCRECT);
 	CRect bgRect(0, 0, refRect.Width(), refRect.Height());

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -28,7 +28,8 @@ source-native `Y`, `U`, and `V` values by default. They are sampled from the
 planes in the selected raw layout, including subsampled and 10-bit formats,
 rather than reconstructed from the displayed RGB image. Press `V` to toggle
 between source YUV values and displayed RGB values. A small corner badge
-identifies the active pixel-value mode without adding labels to every pixel.
+identifies the active pixel-value mode and row order (`Y/U/V` or `R/G/B`)
+without adding labels to every pixel.
 Decoded images and video show RGB values only.
 
 ### Controls


### PR DESCRIPTION
## What changed
- Change the compact pixel mode badge to show the visible row order: `Y/U/V SOURCE` or `R/G/B DISPLAY`.
- Document that the corner badge identifies both the pixel-value mode and row order.

## Why
While validating raw YUV420 inspection, the source-native values were correct but the compact `YUV SOURCE` badge did not make the three displayed rows self-explanatory. This keeps the uncluttered layout while removing ambiguity about whether the values are Y/U/V or another order.

## Validation
- `git diff --check`
- Synthetic YUV420 2x2 sampler assertion: verified per-pixel Y values and shared U/V values in the correct `Y/U/V` order.
- Windows x64 GitHub Actions build will run on this pull request.