### PR TITLE
[codex] Add core image regression tests

### DIFF
--- a/.github/workflows/heif-dependency.yml
+++ b/.github/workflows/heif-dependency.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build HEIF
         shell: pwsh

--- a/.github/workflows/opencv-dependency.yml
+++ b/.github/workflows/opencv-dependency.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Build OpenCV
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
 
+      - name: Build and run core regression tests
+        run: |
+          msbuild Tests\CoreRegressionTests.vcxproj /m /p:Configuration=$env:BUILD_CONFIGURATION /p:Platform=$env:BUILD_PLATFORM /p:PlatformToolset=v143
+          .\Tests\bin\$env:BUILD_PLATFORM\$env:BUILD_CONFIGURATION\CoreRegressionTests.exe
+
       - name: Build Viewer
         run: msbuild Viewer\Viewer.sln /m /restore /p:Configuration=$env:BUILD_CONFIGURATION /p:Platform=$env:BUILD_PLATFORM /p:PlatformToolset=v143
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
           .\build\Sign-Q1View.ps1 -Files "dist\$env:INSTALLER_FILE"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Q1View-windows-x64
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,12 +38,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Build and run core regression tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build and run core regression tests
         run: |
           msbuild Tests\CoreRegressionTests.vcxproj /m /p:Configuration=$env:BUILD_CONFIGURATION /p:Platform=$env:BUILD_PLATFORM /p:PlatformToolset=v143
-          .\Tests\bin\$env:BUILD_PLATFORM\$env:BUILD_CONFIGURATION\CoreRegressionTests.exe
+          & ".\Tests\bin\$env:BUILD_PLATFORM\$env:BUILD_CONFIGURATION\CoreRegressionTests.exe"
 
       - name: Build Viewer
         run: msbuild Viewer\Viewer.sln /m /restore /p:Configuration=$env:BUILD_CONFIGURATION /p:Platform=$env:BUILD_PLATFORM /p:PlatformToolset=v143

--- a/QVisionCore/qimage_cs.c
+++ b/QVisionCore/qimage_cs.c
@@ -1,4 +1,5 @@
 
+#include <limits.h>
 #include <string.h>
 
 #include "qimage_cs.h"
@@ -322,7 +323,7 @@ void qimage_rgba8888_to_bgr888(qu8 *bgr, qu8 *src_argb, qu8 *n1, qu8 *n2,
 
 int qimage_bgr888_load_info(int w, int h, int *bufoff2, int *bufoff3)
 {
-	return qimage_rgb888_load_info(w, h, bufoff2, bufoff2);
+	return qimage_rgb888_load_info(w, h, bufoff2, bufoff3);
 }
 
 void qimage_bgr888_to_bgr888(qu8 *bgr, qu8 *src_bgr, qu8 *n1, qu8 *n2,
@@ -522,8 +523,8 @@ void qimage_rgb16u_to_bgr888(qu8* bgr, qu8* src_rgb, qu8* n1, qu8* n2,
 		for (j = 0; j < w; j++)
 		{
 			int R16 = ((qu16*)src_rgb)[0];
-			int G16 = ((qu16*)src_rgb)[2];
-			int B16 = ((qu16*)src_rgb)[4];
+			int G16 = ((qu16*)src_rgb)[1];
+			int B16 = ((qu16*)src_rgb)[2];
 
 			R16 = ((R16 - RGB16RangeMin) * UCHAR_MAX + range16_half) / range16;
 			G16 = ((G16 - RGB16RangeMin) * UCHAR_MAX + range16_half) / range16;
@@ -649,6 +650,12 @@ void qimage_t256x16_to_bgr888(qu8 *bgr, qu8 *y, qu8 *u, qu8 *v,
 int qimage_grayscale_load_info(int w, int h, int *bufoff2, int *bufoff3)
 {
 	int scene_size = w * h;
+
+	if (bufoff2)
+		*bufoff2 = 0;
+
+	if (bufoff3)
+		*bufoff3 = 0;
 
 	return scene_size;
 }

--- a/QVisionCore/qimage_metrics.c
+++ b/QVisionCore/qimage_metrics.c
@@ -116,7 +116,7 @@ static double ssim_window(qu8 *src, qu8 *dst, int real_w, int px_w)
 double qSSIM(qu8 *src, qu8 *dst, int w, int h, int stride, int px_w)
 {
 	double mean_ssim, total_ssim = 0;
-	int real_w = w * px_w;
+	int real_w = stride * px_w;
 	int i, j;
 	int nW = w - SIZE_N + 1;
 	int nH = h - SIZE_N + 1;

--- a/Tests/CoreRegressionTests.c
+++ b/Tests/CoreRegressionTests.c
@@ -1,0 +1,339 @@
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "qimage_cs.h"
+#include "qimage_metrics.h"
+
+static int failures = 0;
+
+#define CHECK_TRUE(name, condition) do { \
+	if (!(condition)) { \
+		fprintf(stderr, "FAIL: %s\n", name); \
+		failures++; \
+	} \
+} while (0)
+
+typedef int (*LoadInfoFn)(int, int, int *, int *);
+
+static void check_int(const char *name, int actual, int expected)
+{
+	if (actual != expected) {
+		fprintf(stderr, "FAIL: %s expected %d, got %d\n",
+			name, expected, actual);
+		failures++;
+	}
+}
+
+static void check_near(const char *name, double actual, double expected,
+	double tolerance)
+{
+	if (fabs(actual - expected) > tolerance) {
+		fprintf(stderr, "FAIL: %s expected %.12f, got %.12f\n",
+			name, expected, actual);
+		failures++;
+	}
+}
+
+static void check_bytes(const char *name, const qu8 *actual,
+	const qu8 *expected, size_t size)
+{
+	size_t i;
+
+	for (i = 0; i < size; i++) {
+		if (actual[i] != expected[i]) {
+			fprintf(stderr, "FAIL: %s byte %zu expected %u, got %u\n",
+				name, i, expected[i], actual[i]);
+			failures++;
+			return;
+		}
+	}
+}
+
+static void check_layout(const char *name, LoadInfoFn load_info,
+	int w, int h, int expected_size, int expected_off2, int expected_off3)
+{
+	char value_name[96];
+	int off2 = -1;
+	int off3 = -1;
+	int size = load_info(w, h, &off2, &off3);
+
+	snprintf(value_name, sizeof(value_name), "%s size", name);
+	check_int(value_name, size, expected_size);
+	snprintf(value_name, sizeof(value_name), "%s plane 2 offset", name);
+	check_int(value_name, off2, expected_off2);
+	snprintf(value_name, sizeof(value_name), "%s plane 3 offset", name);
+	check_int(value_name, off3, expected_off3);
+}
+
+static void check_sample(const char *name, QIMAGE_SAMPLE_NATIVE_PIXEL_FN fn,
+	const qu8 *src, int w, int h, int x, int y, QIMAGE_PIXEL_MODEL model,
+	int bit_depth, int chroma_x, int chroma_y, int c0, int c1, int c2)
+{
+	QIMAGE_NATIVE_PIXEL_SAMPLE sample = { 0 };
+
+	CHECK_TRUE(name, fn(src, w, h, x, y, &sample) != 0);
+	check_int(name, sample.model, model);
+	check_int(name, sample.bit_depth, bit_depth);
+	check_int(name, sample.chroma_x, chroma_x);
+	check_int(name, sample.chroma_y, chroma_y);
+	check_int(name, sample.component[0], c0);
+	check_int(name, sample.component[1], c1);
+	check_int(name, sample.component[2], c2);
+}
+
+static void test_raw_layouts(void)
+{
+	check_layout("yuv420 odd layout", qimage_yuv420_load_info,
+		3, 3, 17, 9, 13);
+	check_layout("nv12 odd layout", qimage_nv12_load_info,
+		3, 3, 17, 9, 0);
+	check_layout("nv21 odd layout", qimage_nv21_load_info,
+		3, 3, 17, 9, 0);
+	check_layout("yuv420p10le odd layout", qimage_yuv420p10le_load_info,
+		3, 3, 34, 18, 26);
+	check_layout("p010 odd layout", qimage_p010_load_info,
+		3, 3, 34, 18, 0);
+	check_layout("yuv422p10le odd layout", qimage_yuv422p10le_load_info,
+		3, 3, 42, 18, 30);
+	check_layout("p210 odd layout", qimage_p210_load_info,
+		3, 3, 42, 18, 0);
+	check_layout("grayscale layout", qimage_grayscale_load_info,
+		3, 3, 9, 0, 0);
+	check_layout("rgb888 layout", qimage_rgb888_load_info,
+		3, 3, 27, 0, 0);
+	check_layout("bgr888 layout", qimage_bgr888_load_info,
+		3, 3, 27, 0, 0);
+	check_layout("rgba8888 layout", qimage_rgba8888_load_info,
+		3, 3, 36, 0, 0);
+	check_layout("bgr565 layout", qimage_bgr565_load_info,
+		3, 3, 18, 0, 0);
+	check_layout("rgba1010102 layout", qimage_rgba1010102_load_info,
+		3, 3, 36, 0, 0);
+	check_layout("abgr2101010 layout", qimage_abgr2101010_load_info,
+		3, 3, 36, 0, 0);
+	check_layout("rgb16u layout", qimage_rgb16u_load_info,
+		3, 3, 54, 0, 0);
+	check_layout("tiled nv12 layout", qimage_t256x16_load_info,
+		257, 17, 98304, 65536, 0);
+}
+
+static void test_native_yuv8_samples(void)
+{
+	qu8 yuv420[] = {
+		1, 2, 3, 4, 5, 6, 7, 8, 9,
+		101, 102, 103, 104,
+		201, 202, 203, 204
+	};
+	qu8 nv12[] = {
+		1, 2, 3, 4, 5, 6, 7, 8, 9,
+		101, 201, 102, 202, 103, 203, 104, 204
+	};
+	qu8 nv21[] = {
+		1, 2, 3, 4, 5, 6, 7, 8, 9,
+		201, 101, 202, 102, 203, 103, 204, 104
+	};
+	QIMAGE_NATIVE_PIXEL_SAMPLE sample = { 0 };
+
+	check_sample("yuv420 first pixel", qimage_yuv420_sample_native,
+		yuv420, 3, 3, 0, 0, QIMAGE_PIXEL_MODEL_YUV, 8, 0, 0,
+		1, 101, 201);
+	check_sample("yuv420 shared chroma", qimage_yuv420_sample_native,
+		yuv420, 3, 3, 1, 1, QIMAGE_PIXEL_MODEL_YUV, 8, 0, 0,
+		5, 101, 201);
+	check_sample("yuv420 odd edge", qimage_yuv420_sample_native,
+		yuv420, 3, 3, 2, 2, QIMAGE_PIXEL_MODEL_YUV, 8, 1, 1,
+		9, 104, 204);
+	CHECK_TRUE("yuv420 rejects out of range",
+		qimage_yuv420_sample_native(yuv420, 3, 3, 3, 0, &sample) == 0);
+
+	check_sample("nv12 odd edge", qimage_nv12_sample_native,
+		nv12, 3, 3, 2, 2, QIMAGE_PIXEL_MODEL_YUV, 8, 1, 1,
+		9, 104, 204);
+	check_sample("nv21 odd edge", qimage_nv21_sample_native,
+		nv21, 3, 3, 2, 2, QIMAGE_PIXEL_MODEL_YUV, 8, 1, 1,
+		9, 104, 204);
+}
+
+static void test_native_yuv10_samples(void)
+{
+	qu16 planar420[] = {
+		10, 11, 12, 13, 14, 15, 16, 17, 18,
+		600, 601, 602, 603,
+		700, 701, 702, 703
+	};
+	qu16 p010[] = {
+		10 << 6, 11 << 6, 12 << 6, 13 << 6, 14 << 6, 15 << 6,
+		16 << 6, 17 << 6, 18 << 6,
+		600 << 6, 700 << 6, 601 << 6, 701 << 6,
+		602 << 6, 702 << 6, 603 << 6, 703 << 6
+	};
+	qu16 planar422[] = {
+		10, 11, 12, 13, 14, 15,
+		400, 401, 402, 403,
+		500, 501, 502, 503
+	};
+	qu16 p210[] = {
+		10 << 6, 11 << 6, 12 << 6, 13 << 6, 14 << 6, 15 << 6,
+		400 << 6, 500 << 6, 401 << 6, 501 << 6,
+		402 << 6, 502 << 6, 403 << 6, 503 << 6
+	};
+
+	check_sample("yuv420p10le odd edge", qimage_yuv420p10le_sample_native,
+		(const qu8 *)planar420, 3, 3, 2, 2, QIMAGE_PIXEL_MODEL_YUV,
+		10, 1, 1, 18, 603, 703);
+	check_sample("p010 odd edge", qimage_p010_sample_native,
+		(const qu8 *)p010, 3, 3, 2, 2, QIMAGE_PIXEL_MODEL_YUV,
+		10, 1, 1, 18, 603, 703);
+	check_sample("yuv422p10le second row", qimage_yuv422p10le_sample_native,
+		(const qu8 *)planar422, 3, 2, 2, 1, QIMAGE_PIXEL_MODEL_YUV,
+		10, 1, 1, 15, 403, 503);
+	check_sample("p210 second row", qimage_p210_sample_native,
+		(const qu8 *)p210, 3, 2, 2, 1, QIMAGE_PIXEL_MODEL_YUV,
+		10, 1, 1, 15, 403, 503);
+}
+
+static void test_tiled_and_packed_native_samples(void)
+{
+	int size = qimage_t256x16_load_info(257, 17, NULL, NULL);
+	qu8 *tiled = (qu8 *)calloc((size_t)size, 1);
+	qu32 abgr = (9u << 20) | (8u << 10) | 7u;
+
+	CHECK_TRUE("allocate tiled fixture", tiled != NULL);
+	if (tiled != NULL) {
+		tiled[36864] = 19;
+		tiled[65536 + 6144] = 111;
+		tiled[65536 + 6145] = 211;
+		check_sample("tiled nv12 tile crossing", qimage_t256x16_sample_native,
+			tiled, 257, 17, 256, 16, QIMAGE_PIXEL_MODEL_YUV,
+			8, 128, 8, 19, 111, 211);
+		free(tiled);
+	}
+
+	check_sample("abgr2101010 native rgb", qimage_abgr2101010_sample_native,
+		(const qu8 *)&abgr, 1, 1, 0, 0, QIMAGE_PIXEL_MODEL_RGB,
+		10, 0, 0, 7, 8, 9);
+}
+
+static void test_yuv_display_conversions(void)
+{
+	qu8 y[] = { 81, 145, 41, 210 };
+	qu8 u[] = { 90 };
+	qu8 v[] = { 240 };
+	qu8 uv[] = { 90, 240 };
+	qu8 vu[] = { 240, 90 };
+	qu16 y10[] = { 81 << 2, 145 << 2, 41 << 2, 210 << 2 };
+	qu16 u10[] = { 90 << 2 };
+	qu16 v10[] = { 240 << 2 };
+	qu16 p010[] = {
+		81 << 8, 145 << 8, 41 << 8, 210 << 8, 90 << 8, 240 << 8
+	};
+	qu8 out[12];
+	const qu8 expected[] = {
+		0, 0, 255, 74, 74, 255, 0, 0, 208, 149, 150, 255
+	};
+
+	qimage_yuv420_to_bgr888(out, y, u, v, 2, 2, 2);
+	check_bytes("yuv420 display conversion", out, expected, sizeof(expected));
+	qimage_nv12_to_bgr888(out, y, uv, NULL, 2, 2, 2);
+	check_bytes("nv12 display conversion", out, expected, sizeof(expected));
+	qimage_nv21_to_bgr888(out, y, vu, NULL, 2, 2, 2);
+	check_bytes("nv21 display conversion", out, expected, sizeof(expected));
+	qimage_yuv420p10le_to_bgr888(out, (qu8 *)y10, (qu8 *)u10,
+		(qu8 *)v10, 2, 2, 2);
+	check_bytes("yuv420p10le display conversion", out, expected,
+		sizeof(expected));
+	qimage_p010_to_bgr888(out, (qu8 *)p010, (qu8 *)(p010 + 4),
+		NULL, 2, 2, 2);
+	check_bytes("p010 display conversion", out, expected, sizeof(expected));
+}
+
+static void test_rgb_display_conversions(void)
+{
+	qu8 out[6];
+	qu8 rgb888[] = { 12, 34, 56 };
+	qu8 rgba8888[] = { 12, 34, 56, 99 };
+	qu8 bgr888[] = { 56, 34, 12 };
+	qu8 bgr565[] = { 0x00, 0xf8 };
+	qu32 rgba1010102 = (1023u << 22) | (512u << 2);
+	qu32 abgr2101010 = (512u << 20) | 1023u;
+	qu16 rgb16u[] = { 65535, 0, 32768 };
+	qu8 gray[] = { 4, 200 };
+	const qu8 bgr_expected[] = { 56, 34, 12 };
+	const qu8 packed_expected[] = { 128, 0, 255 };
+	const qu8 bgr565_expected[] = { 4, 2, 252 };
+	const qu8 gray_expected[] = { 4, 4, 4, 200, 200, 200 };
+
+	qimage_rgb888_to_bgr888(out, rgb888, NULL, NULL, 1, 1, 1);
+	check_bytes("rgb888 display conversion", out, bgr_expected, 3);
+	qimage_rgba8888_to_bgr888(out, rgba8888, NULL, NULL, 1, 1, 1);
+	check_bytes("rgba8888 display conversion", out, bgr_expected, 3);
+	qimage_bgr888_to_bgr888(out, bgr888, NULL, NULL, 1, 1, 1);
+	check_bytes("bgr888 display conversion", out, bgr_expected, 3);
+	qimage_bgr565_to_bgr888(out, bgr565, NULL, NULL, 1, 1, 1);
+	check_bytes("bgr565 display conversion", out, bgr565_expected, 3);
+	qimage_rgba1010102_to_bgr888(out, (qu8 *)&rgba1010102, NULL, NULL,
+		1, 1, 1);
+	check_bytes("rgba1010102 display conversion", out, packed_expected, 3);
+	qimage_abgr2101010_to_bgr888(out, (qu8 *)&abgr2101010, NULL, NULL,
+		1, 1, 1);
+	check_bytes("abgr2101010 display conversion", out, packed_expected, 3);
+	qimage_rgb16u_to_bgr888(out, (qu8 *)rgb16u, NULL, NULL, 1, 1, 1);
+	check_bytes("rgb16u display conversion", out, packed_expected, 3);
+	qimage_grayscale_to_bgr888(out, gray, NULL, NULL, 2, 2, 1);
+	check_bytes("grayscale display conversion", out, gray_expected, 6);
+}
+
+static void test_metrics(void)
+{
+	qu8 psnr_src[] = { 0, 0, 255, 0, 0, 255 };
+	qu8 psnr_dst[] = { 0, 10, 0, 0, 0, 0 };
+	qu8 ssim_src[80];
+	qu8 ssim_dst[80];
+	qu8 zero[64] = { 0 };
+	qu8 ten[64];
+	int x;
+	int y;
+
+	check_near("PSNR ignores padded samples",
+		qPSNR(psnr_src, psnr_dst, 2, 2, 3, 1),
+		34.151403521959, 0.000000001);
+
+	memset(ssim_src, 0, sizeof(ssim_src));
+	memset(ssim_dst, 0, sizeof(ssim_dst));
+	for (y = 0; y < 8; y++) {
+		for (x = 0; x < 8; x++) {
+			ssim_src[y * 10 + x] = (qu8)(y * 8 + x);
+			ssim_dst[y * 10 + x] = ssim_src[y * 10 + x];
+		}
+		ssim_dst[y * 10 + 8] = 255;
+		ssim_dst[y * 10 + 9] = 255;
+	}
+	check_near("SSIM ignores padded samples",
+		qSSIM(ssim_src, ssim_dst, 8, 8, 10, 1), 1.0, 0.000000001);
+
+	memset(ten, 10, sizeof(ten));
+	check_near("SSIM constant reference",
+		qSSIM(zero, ten, 8, 8, 8, 1),
+		6.5025 / 106.5025, 0.000000001);
+}
+
+int main(void)
+{
+	test_raw_layouts();
+	test_native_yuv8_samples();
+	test_native_yuv10_samples();
+	test_tiled_and_packed_native_samples();
+	test_yuv_display_conversions();
+	test_rgb_display_conversions();
+	test_metrics();
+
+	if (failures != 0) {
+		fprintf(stderr, "%d core regression test failure(s)\n", failures);
+		return 1;
+	}
+
+	puts("Core regression tests passed.");
+	return 0;
+}

--- a/Tests/CoreRegressionTests.vcxproj
+++ b/Tests/CoreRegressionTests.vcxproj
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{DAE30D4B-BE04-4F49-8FCA-282A7B978608}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>CoreRegressionTests</RootNamespace>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings" />
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <OutDir>$(ProjectDir)bin\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)obj\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\QCommon\inc;..\QVisionCore;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>..\QCommon\inc;..\QVisionCore;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="CoreRegressionTests.c" />
+    <ClCompile Include="..\QVisionCore\qimage_cs.c" />
+    <ClCompile Include="..\QVisionCore\qimage_metrics.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets" />
+</Project>

--- a/Tests/run_core_regression_tests.sh
+++ b/Tests/run_core_regression_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+test_bin="${TMPDIR:-/tmp}/q1view-core-regression-tests-$$"
+
+cleanup()
+{
+	rm -f "$test_bin"
+}
+trap cleanup EXIT INT TERM
+
+"${CC:-cc}" -std=c11 -Wall -Wextra -Wno-unused-parameter \
+	-I "$repo_root/QCommon/inc" \
+	-I "$repo_root/QVisionCore" \
+	"$repo_root/Tests/CoreRegressionTests.c" \
+	"$repo_root/QVisionCore/qimage_cs.c" \
+	"$repo_root/QVisionCore/qimage_metrics.c" \
+	-lm -o "$test_bin"
+
+"$test_bin"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -20,6 +20,28 @@ Normal builds restore prebuilt OpenCV and libheif dependency archives into
 `.deps`. Dedicated GitHub Actions workflows create updated dependency archives
 when dependency versions change.
 
+## Core Regression Tests
+
+The portable core suite verifies raw layout sizing, source-native pixel
+sampling, RGB conversion outputs, and PSNR/SSIM reference values with small
+deterministic fixtures.
+
+On macOS or Linux:
+
+```sh
+./Tests/run_core_regression_tests.sh
+```
+
+From a Visual Studio Developer PowerShell on Windows:
+
+```powershell
+msbuild Tests\CoreRegressionTests.vcxproj /m /p:Configuration=Release /p:Platform=x64
+.\Tests\bin\x64\Release\CoreRegressionTests.exe
+```
+
+The Windows GitHub Actions build runs this suite before building the
+applications.
+
 ## Package Locally
 
 After both applications are built:


### PR DESCRIPTION
Addresses #29

## What changed
- Add a portable `CoreRegressionTests` executable with explicit fixtures for raw layout sizing, source-native pixel sampling, YUV/RGB display conversion, and PSNR/SSIM reference checks.
- Add a local macOS/Linux shell runner and a Windows MSBuild test project.
- Run the core regression suite in the existing Windows GitHub Actions workflow before the application builds.
- Document local test commands in the development guide.

## Fixes found while adding coverage
- Initialize the correct third plane offset for `bgr888` and initialize both unused plane offsets for grayscale inputs.
- Read contiguous R/G/B 16-bit channels in `rgb16u` conversion instead of reaching beyond a three-channel pixel.
- Honor row stride in `qSSIM`, so padded display buffers do not change metrics when visible pixels are identical.
- Include `<limits.h>` directly for the packed RGB conversion constants used by the standalone core build.

## Coverage
- Odd-size YUV420, NV12, NV21, YUV420P10LE, YUV422P10LE, P010, and P210 layout/coordinate behavior.
- Source-native Y/U/V checks, including subsampled sharing, semi-planar ordering, 10-bit packing, and tiled NV12 addressing.
- Display conversion checks for YUV, NV12/NV21, 10-bit YUV, RGB/BGR/RGBA, grayscale, and packed RGB inputs.
- Reference PSNR/SSIM checks, including padded-stride isolation.

Unicode-path and frame-navigation coverage remain better suited to a later application-level integration test layer rather than this UI-independent core executable.

## Validation
- `git diff --check`
- `./Tests/run_core_regression_tests.sh`
- Clang AddressSanitizer and UndefinedBehaviorSanitizer build/run of `Tests/CoreRegressionTests.c` against `qimage_cs.c` and `qimage_metrics.c`
- Windows x64 GitHub Actions build will compile and run the new MSBuild test target.