### PR TITLE
Fix Comparer CLI startup and validate Store MSIX

### DIFF
--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -179,7 +179,7 @@ jobs:
           }
 
           Capture-AppWindow "Viewer.exe" "`"$reference`"" "artifacts\screenshots\viewer.png"
-          Capture-AppWindow "Comparer.exe" "`"$reference|$encoded`"" "artifacts\screenshots\comparer.png"
+          Capture-AppWindow "Comparer.exe" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
 
       - name: Uninstall smoke-tested package
         shell: pwsh

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -193,8 +193,10 @@ jobs:
           Invoke-WebRequest "https://download.sysinternals.com/files/Procdump.zip" -OutFile $procdumpZip
           Expand-Archive -Path $procdumpZip -DestinationPath $procdumpDir -Force
           $comparerExe = (Resolve-Path (Join-Path $env:DIST_DIR "Comparer.exe")).Path
-          & (Join-Path $procdumpDir "procdump64.exe") -accepteula -ma -e 1 -n 1 -x $diagnostics `
+          Remove-Item -Path $dumpKey -Recurse -Force
+          & (Join-Path $procdumpDir "procdump64.exe") -accepteula -e 1 -n 1 -x $diagnostics `
             $comparerExe $reference $encoded
+          Get-Process Comparer -ErrorAction SilentlyContinue | Stop-Process -Force
           Get-ChildItem $diagnostics | Format-Table Name, Length |
             Out-File "artifacts\diagnostics\procdump-files.txt"
           throw "Comparer first-chance diagnostic dump captured; inspect diagnostics artifact."
@@ -250,7 +252,6 @@ jobs:
         with:
           name: Q1View-store-validation-trial
           path: |
-            artifacts/store-submission/
             artifacts/screenshots/
             artifacts/diagnostics/
             artifacts/validation/WACKReport.xml

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -188,6 +188,17 @@ jobs:
           }
 
           Capture-AppWindow "Viewer" "`"$reference`"" "artifacts\screenshots\viewer.png"
+          $procdumpZip = Join-Path $env:TEMP "Procdump.zip"
+          $procdumpDir = Join-Path $env:TEMP "Procdump"
+          Invoke-WebRequest "https://download.sysinternals.com/files/Procdump.zip" -OutFile $procdumpZip
+          Expand-Archive -Path $procdumpZip -DestinationPath $procdumpDir -Force
+          $comparerExe = (Resolve-Path (Join-Path $env:DIST_DIR "Comparer.exe")).Path
+          & (Join-Path $procdumpDir "procdump64.exe") -accepteula -ma -e 1 -n 1 -x $diagnostics `
+            $comparerExe $reference $encoded
+          Get-ChildItem $diagnostics | Format-Table Name, Length |
+            Out-File "artifacts\diagnostics\procdump-files.txt"
+          throw "Comparer first-chance diagnostic dump captured; inspect diagnostics artifact."
+
           try {
             Capture-AppWindow "Comparer" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
           }

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -82,7 +82,7 @@ jobs:
             Format-List * | Out-File "artifacts\validation\signature.txt"
 
       - name: Install package and record identity
-        shell: pwsh
+        shell: powershell
         run: |
           Add-AppxPackage -Path "artifacts\validation\Q1View-validation.msix"
           $pkg = Get-AppxPackage -Name "KyuwonKim.Q1View"
@@ -106,7 +106,7 @@ jobs:
 
       - name: Capture installed application windows
         continue-on-error: true
-        shell: pwsh
+        shell: powershell
         run: |
           New-Item -ItemType Directory -Force "artifacts\screenshots" | Out-Null
           choco install qres --no-progress --yes
@@ -182,7 +182,7 @@ jobs:
           Capture-AppWindow "Comparer.exe" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
 
       - name: Uninstall smoke-tested package
-        shell: pwsh
+        shell: powershell
         run: |
           $pkg = Get-AppxPackage -Name "KyuwonKim.Q1View"
           if (-not $pkg) {

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -121,6 +121,8 @@ jobs:
           public static class Q1WindowTools {
               [DllImport("user32.dll")]
               public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+              [DllImport("user32.dll")]
+              public static extern IntPtr SendMessage(IntPtr hWnd, uint msg, UIntPtr wParam, IntPtr lParam);
           }
           "@
 
@@ -184,6 +186,48 @@ jobs:
           Capture-AppWindow "Viewer" "`"$reference`"" "artifacts\screenshots\viewer.png"
           Capture-AppWindow "Comparer" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
 
+          $viewerPath = (Resolve-Path (Join-Path $env:DIST_DIR "Viewer.exe")).Path
+          $viewerProcess = Start-Process -FilePath $viewerPath `
+            -WorkingDirectory $env:RUNNER_TEMP -ArgumentList "`"$reference`"" -PassThru
+          $comparerProcess = $null
+          try {
+            foreach ($attempt in 1..20) {
+              Start-Sleep -Milliseconds 500
+              $viewerProcess.Refresh()
+              if ($viewerProcess.HasExited) {
+                throw "Viewer exited before its Compare action could be tested."
+              }
+              if ($viewerProcess.MainWindowHandle -ne 0) {
+                break
+              }
+            }
+            if ($viewerProcess.MainWindowHandle -eq 0) {
+              throw "Viewer did not create a window for its Compare action test."
+            }
+            [Q1WindowTools]::SendMessage($viewerProcess.MainWindowHandle, 0x0111, [UIntPtr]32771, [IntPtr]::Zero) | Out-Null
+            foreach ($attempt in 1..20) {
+              Start-Sleep -Milliseconds 500
+              $comparerProcess = Get-Process -Name "Comparer" -ErrorAction SilentlyContinue |
+                Select-Object -First 1
+              if ($comparerProcess -and $comparerProcess.MainWindowHandle -ne 0) {
+                break
+              }
+            }
+            if (-not $comparerProcess -or $comparerProcess.MainWindowHandle -eq 0) {
+              throw "Viewer's Compare action did not open the packaged Comparer executable."
+            }
+            "Viewer Compare action opened the packaged Comparer executable from a different working directory." |
+              Out-File "artifacts\screenshots\capture-result.txt" -Append
+          }
+          finally {
+            if ($comparerProcess -and -not $comparerProcess.HasExited) {
+              Stop-Process -Id $comparerProcess.Id -Force
+            }
+            if (-not $viewerProcess.HasExited) {
+              Stop-Process -Id $viewerProcess.Id -Force
+            }
+          }
+
       - name: Uninstall smoke-tested package
         shell: powershell
         run: |
@@ -216,6 +260,22 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "WACK failed with exit code $LASTEXITCODE. See WACKReport.xml."
           }
+          [xml]$report = Get-Content "artifacts\validation\WACKReport.xml"
+          $failedTests = @($report.REPORT.REQUIREMENTS.REQUIREMENT.TEST |
+            Where-Object { $_.RESULT.InnerText -eq "FAIL" })
+          "WACK overall result: $($report.REPORT.OVERALL_RESULT)" |
+            Out-File "artifacts\validation\wack-summary.txt"
+          foreach ($test in $failedTests) {
+            $failure = "WACK failed test: $($test.NAME) (optional=$($test.OPTIONAL))"
+            Write-Warning $failure
+            $failure | Out-File "artifacts\validation\wack-summary.txt" -Append
+          }
+          $blockingFailures = @($failedTests | Where-Object {
+            $_.OPTIONAL -ne "TRUE" -or $_.NAME -eq "Application count"
+          })
+          if ($blockingFailures.Count -gt 0) {
+            throw "WACK reported a Store-blocking failure. See WACKReport.xml."
+          }
 
       - name: Upload validation output
         if: always()
@@ -230,3 +290,4 @@ jobs:
             artifacts/validation/installed-package.txt
             artifacts/validation/install-uninstall-result.txt
             artifacts/validation/wack-command.txt
+            artifacts/validation/wack-summary.txt

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -108,12 +108,6 @@ jobs:
         shell: powershell
         run: |
           New-Item -ItemType Directory -Force "artifacts\screenshots" | Out-Null
-          $diagnostics = (New-Item -ItemType Directory -Force "artifacts\diagnostics").FullName
-          $dumpKey = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\Comparer.exe"
-          New-Item -Path $dumpKey -Force | Out-Null
-          New-ItemProperty -Path $dumpKey -Name DumpFolder -PropertyType ExpandString -Value $diagnostics -Force | Out-Null
-          New-ItemProperty -Path $dumpKey -Name DumpType -PropertyType DWord -Value 2 -Force | Out-Null
-          Copy-Item "Comparer\x64\Release\Comparer.pdb" $diagnostics -ErrorAction SilentlyContinue
           Import-Module ServerCore -ErrorAction SilentlyContinue
           if (Get-Command Set-DisplayResolution -ErrorAction SilentlyContinue) {
             Set-DisplayResolution -Width 1920 -Height 1080 -Force
@@ -142,7 +136,7 @@ jobs:
                 $process.Refresh()
                 if ($process.HasExited) {
                   "$appId exit code before capture: $($process.ExitCode)" |
-                    Out-File "artifacts\diagnostics\process-exits.txt" -Append
+                    Out-File "artifacts\screenshots\capture-result.txt" -Append
                   throw "$appId exited before its window could be captured (exit code $($process.ExitCode))."
                 }
                 if ($process.MainWindowHandle -ne 0) {
@@ -157,7 +151,7 @@ jobs:
               $process.Refresh()
               if ($process.HasExited) {
                 "$appId exit code after open: $($process.ExitCode)" |
-                  Out-File "artifacts\diagnostics\process-exits.txt" -Append
+                  Out-File "artifacts\screenshots\capture-result.txt" -Append
                 throw "$appId exited after opening its command-line source input (exit code $($process.ExitCode))."
               }
 
@@ -178,7 +172,7 @@ jobs:
                 $bitmap.Dispose()
               }
               "$appId remained running through screenshot capture." |
-                Out-File "artifacts\diagnostics\process-exits.txt" -Append
+                Out-File "artifacts\screenshots\capture-result.txt" -Append
             }
             finally {
               if (-not $process.HasExited) {
@@ -188,30 +182,7 @@ jobs:
           }
 
           Capture-AppWindow "Viewer" "`"$reference`"" "artifacts\screenshots\viewer.png"
-          $procdumpZip = Join-Path $env:TEMP "Procdump.zip"
-          $procdumpDir = Join-Path $env:TEMP "Procdump"
-          Invoke-WebRequest "https://download.sysinternals.com/files/Procdump.zip" -OutFile $procdumpZip
-          Expand-Archive -Path $procdumpZip -DestinationPath $procdumpDir -Force
-          $comparerExe = (Resolve-Path (Join-Path $env:DIST_DIR "Comparer.exe")).Path
-          Remove-Item -Path $dumpKey -Recurse -Force
-          & (Join-Path $procdumpDir "procdump64.exe") -accepteula -e 1 -n 1 -x $diagnostics `
-            $comparerExe $reference $encoded
-          Get-Process Comparer -ErrorAction SilentlyContinue | Stop-Process -Force
-          Get-ChildItem $diagnostics | Format-Table Name, Length |
-            Out-File "artifacts\diagnostics\procdump-files.txt"
-          throw "Comparer first-chance diagnostic dump captured; inspect diagnostics artifact."
-
-          try {
-            Capture-AppWindow "Comparer" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
-          }
-          catch {
-            Start-Sleep -Seconds 2
-            Get-WinEvent -FilterHashtable @{LogName="Application"; StartTime=(Get-Date).AddMinutes(-5)} -ErrorAction SilentlyContinue |
-              Where-Object {$_.ProviderName -eq "Application Error" -or $_.ProviderName -eq "Windows Error Reporting"} |
-              Format-List TimeCreated, ProviderName, Id, Message |
-              Out-File "artifacts\diagnostics\application-errors.txt"
-            throw
-          }
+          Capture-AppWindow "Comparer" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
 
       - name: Uninstall smoke-tested package
         shell: powershell
@@ -252,8 +223,8 @@ jobs:
         with:
           name: Q1View-store-validation-trial
           path: |
+            artifacts/store-submission/
             artifacts/screenshots/
-            artifacts/diagnostics/
             artifacts/validation/WACKReport.xml
             artifacts/validation/signature.txt
             artifacts/validation/installed-package.txt

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -149,6 +149,10 @@ jobs:
               }
               [Q1WindowTools]::ShowWindowAsync($process.MainWindowHandle, 3) | Out-Null
               Start-Sleep -Seconds 3
+              $process.Refresh()
+              if ($process.HasExited) {
+                throw "$exeName exited after opening its command-line source input."
+              }
 
               $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
               "$exeName primary screen: $($bounds.Width)x$($bounds.Height)" |

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -109,10 +109,9 @@ jobs:
         shell: powershell
         run: |
           New-Item -ItemType Directory -Force "artifacts\screenshots" | Out-Null
-          choco install qres --no-progress --yes
-          $qres = Get-Command QRes.exe -ErrorAction SilentlyContinue
-          if ($qres) {
-            & $qres.Source /x:1920 /y:1080
+          Import-Module ServerCore -ErrorAction SilentlyContinue
+          if (Get-Command Set-DisplayResolution -ErrorAction SilentlyContinue) {
+            Set-DisplayResolution -Width 1920 -Height 1080 -Force
           }
 
           Add-Type -AssemblyName System.Drawing
@@ -124,38 +123,65 @@ jobs:
               [DllImport("user32.dll")]
               public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
           }
+
+          [ComImport, Guid("2e941141-7f97-4756-ba1a-9decde894a3d"),
+           InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+          interface IApplicationActivationManager {
+              [PreserveSig]
+              int ActivateApplication(
+                  [In, MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+                  [In, MarshalAs(UnmanagedType.LPWStr)] string arguments,
+                  [In] uint options,
+                  [Out] out uint processId);
+          }
+
+          [ComImport, Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
+          class ApplicationActivationManager {
+          }
+
+          public static class Q1AppLauncher {
+              public static int Launch(string appUserModelId, string arguments) {
+                  IApplicationActivationManager manager =
+                      (IApplicationActivationManager)new ApplicationActivationManager();
+                  uint processId;
+                  int result = manager.ActivateApplication(appUserModelId, arguments, 0, out processId);
+                  Marshal.ThrowExceptionForHR(result);
+                  return (int)processId;
+              }
+          }
           "@
 
           $pkg = Get-AppxPackage -Name "KyuwonKim.Q1View"
           $reference = (Resolve-Path "artifacts\screenshots\input\reference.png").Path
           $encoded = (Resolve-Path "artifacts\screenshots\input\encoded.jpg").Path
 
-          function Capture-AppWindow([string]$exeName, [string]$arguments, [string]$destination) {
-            $exePath = Join-Path $pkg.InstallLocation $exeName
-            $process = Start-Process -FilePath $exePath -ArgumentList $arguments -PassThru
+          function Capture-AppWindow([string]$appId, [string]$arguments, [string]$destination) {
+            $appUserModelId = "$($pkg.PackageFamilyName)!$appId"
+            $processId = [Q1AppLauncher]::Launch($appUserModelId, $arguments)
+            $process = Get-Process -Id $processId -ErrorAction Stop
             try {
               foreach ($attempt in 1..20) {
                 Start-Sleep -Milliseconds 500
                 $process.Refresh()
                 if ($process.HasExited) {
-                  throw "$exeName exited before its window could be captured."
+                  throw "$appId exited before its window could be captured."
                 }
                 if ($process.MainWindowHandle -ne 0) {
                   break
                 }
               }
               if ($process.MainWindowHandle -eq 0) {
-                throw "No visible window was created for $exeName."
+                throw "No visible window was created for $appId."
               }
               [Q1WindowTools]::ShowWindowAsync($process.MainWindowHandle, 3) | Out-Null
               Start-Sleep -Seconds 3
               $process.Refresh()
               if ($process.HasExited) {
-                throw "$exeName exited after opening its command-line source input."
+                throw "$appId exited after opening its command-line source input."
               }
 
               $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
-              "$exeName primary screen: $($bounds.Width)x$($bounds.Height)" |
+              "$appId primary screen: $($bounds.Width)x$($bounds.Height)" |
                 Out-File "artifacts\screenshots\display.txt" -Append
               if ($bounds.Width -lt 1366 -or $bounds.Height -lt 768) {
                 throw "Screen resolution $($bounds.Width)x$($bounds.Height) is below Store screenshot minimum."
@@ -178,8 +204,8 @@ jobs:
             }
           }
 
-          Capture-AppWindow "Viewer.exe" "`"$reference`"" "artifacts\screenshots\viewer.png"
-          Capture-AppWindow "Comparer.exe" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
+          Capture-AppWindow "Viewer" "`"$reference`"" "artifacts\screenshots\viewer.png"
+          Capture-AppWindow "Comparer" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
 
       - name: Uninstall smoke-tested package
         shell: powershell

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -108,6 +108,12 @@ jobs:
         shell: powershell
         run: |
           New-Item -ItemType Directory -Force "artifacts\screenshots" | Out-Null
+          $diagnostics = (New-Item -ItemType Directory -Force "artifacts\diagnostics").FullName
+          $dumpKey = "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\Comparer.exe"
+          New-Item -Path $dumpKey -Force | Out-Null
+          New-ItemProperty -Path $dumpKey -Name DumpFolder -PropertyType ExpandString -Value $diagnostics -Force | Out-Null
+          New-ItemProperty -Path $dumpKey -Name DumpType -PropertyType DWord -Value 2 -Force | Out-Null
+          Copy-Item "Comparer\x64\Release\Comparer.pdb" $diagnostics -ErrorAction SilentlyContinue
           Import-Module ServerCore -ErrorAction SilentlyContinue
           if (Get-Command Set-DisplayResolution -ErrorAction SilentlyContinue) {
             Set-DisplayResolution -Width 1920 -Height 1080 -Force
@@ -135,7 +141,9 @@ jobs:
                 Start-Sleep -Milliseconds 500
                 $process.Refresh()
                 if ($process.HasExited) {
-                  throw "$appId exited before its window could be captured."
+                  "$appId exit code before capture: $($process.ExitCode)" |
+                    Out-File "artifacts\diagnostics\process-exits.txt" -Append
+                  throw "$appId exited before its window could be captured (exit code $($process.ExitCode))."
                 }
                 if ($process.MainWindowHandle -ne 0) {
                   break
@@ -148,7 +156,9 @@ jobs:
               Start-Sleep -Seconds 3
               $process.Refresh()
               if ($process.HasExited) {
-                throw "$appId exited after opening its command-line source input."
+                "$appId exit code after open: $($process.ExitCode)" |
+                  Out-File "artifacts\diagnostics\process-exits.txt" -Append
+                throw "$appId exited after opening its command-line source input (exit code $($process.ExitCode))."
               }
 
               $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
@@ -167,6 +177,8 @@ jobs:
                 $graphics.Dispose()
                 $bitmap.Dispose()
               }
+              "$appId remained running through screenshot capture." |
+                Out-File "artifacts\diagnostics\process-exits.txt" -Append
             }
             finally {
               if (-not $process.HasExited) {
@@ -176,7 +188,17 @@ jobs:
           }
 
           Capture-AppWindow "Viewer" "`"$reference`"" "artifacts\screenshots\viewer.png"
-          Capture-AppWindow "Comparer" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
+          try {
+            Capture-AppWindow "Comparer" "`"$reference`" `"$encoded`"" "artifacts\screenshots\comparer.png"
+          }
+          catch {
+            Start-Sleep -Seconds 2
+            Get-WinEvent -FilterHashtable @{LogName="Application"; StartTime=(Get-Date).AddMinutes(-5)} -ErrorAction SilentlyContinue |
+              Where-Object {$_.ProviderName -eq "Application Error" -or $_.ProviderName -eq "Windows Error Reporting"} |
+              Format-List TimeCreated, ProviderName, Id, Message |
+              Out-File "artifacts\diagnostics\application-errors.txt"
+            throw
+          }
 
       - name: Uninstall smoke-tested package
         shell: powershell
@@ -219,6 +241,7 @@ jobs:
           path: |
             artifacts/store-submission/
             artifacts/screenshots/
+            artifacts/diagnostics/
             artifacts/validation/WACKReport.xml
             artifacts/validation/signature.txt
             artifacts/validation/installed-package.txt

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -1,0 +1,219 @@
+name: Store Validation Trial
+
+on:
+  push:
+    branches:
+      - codex/store-validation
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BUILD_CONFIGURATION: Release
+  BUILD_PLATFORM: x64
+  DIST_DIR: dist/Q1View-windows-x64
+  STORE_VERSION: 1.0.16.0
+  STORE_PUBLISHER: CN=A89D24B3-A271-4AE1-9B9E-BFAE414EB0C6
+
+jobs:
+  validate:
+    name: Install, WACK, and capture on Windows
+    runs-on: windows-2022
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v3
+
+      - name: Build applications
+        shell: pwsh
+        run: |
+          msbuild Viewer\Viewer.sln /m /restore /p:Configuration=$env:BUILD_CONFIGURATION /p:Platform=$env:BUILD_PLATFORM /p:PlatformToolset=v143
+          msbuild Comparer\Comparer.sln /m /restore /p:Configuration=$env:BUILD_CONFIGURATION /p:Platform=$env:BUILD_PLATFORM /p:PlatformToolset=v143
+          .\build\Package-Q1View.ps1 `
+            -Configuration $env:BUILD_CONFIGURATION `
+            -Platform $env:BUILD_PLATFORM `
+            -OutputDir $env:DIST_DIR
+
+      - name: Build Store submission MSIX
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force "artifacts\store-submission" | Out-Null
+          .\build\Package-Q1ViewMsix.ps1 `
+            -SourceDir $env:DIST_DIR `
+            -OutputDir "dist" `
+            -AppVersion $env:STORE_VERSION `
+            -Publisher $env:STORE_PUBLISHER `
+            -SkipSigning
+          Copy-Item "dist\Q1View-windows-x64.msix" "artifacts\store-submission\Q1View-windows-x64.msix"
+
+      - name: Create certificate for sideload validation
+        id: dev_cert
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force "artifacts\validation" | Out-Null
+          $cert = New-SelfSignedCertificate `
+            -Type Custom `
+            -Subject "CN=Q1ViewValidation" `
+            -KeyUsage DigitalSignature `
+            -FriendlyName "Q1View Store validation" `
+            -CertStoreLocation "Cert:\CurrentUser\My" `
+            -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3")
+          $cerPath = Join-Path $PWD "artifacts\validation\Q1ViewValidation.cer"
+          Export-Certificate -Cert $cert -FilePath $cerPath | Out-Null
+          Import-Certificate -FilePath $cerPath -CertStoreLocation "Cert:\LocalMachine\TrustedPeople" | Out-Null
+          "thumbprint=$($cert.Thumbprint)" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Build signed validation MSIX
+        shell: pwsh
+        run: |
+          .\build\Package-Q1ViewMsix.ps1 `
+            -SourceDir $env:DIST_DIR `
+            -OutputDir "dist" `
+            -AppVersion $env:STORE_VERSION `
+            -Publisher "CN=Q1ViewValidation" `
+            -CertificateThumbprint "${{ steps.dev_cert.outputs.thumbprint }}"
+          Copy-Item "dist\Q1View-windows-x64.msix" "artifacts\validation\Q1View-validation.msix"
+          Get-AuthenticodeSignature "artifacts\validation\Q1View-validation.msix" |
+            Format-List * | Out-File "artifacts\validation\signature.txt"
+
+      - name: Install package and record identity
+        shell: pwsh
+        run: |
+          Add-AppxPackage -Path "artifacts\validation\Q1View-validation.msix"
+          $pkg = Get-AppxPackage -Name "KyuwonKim.Q1View"
+          if (-not $pkg) {
+            throw "The installed Q1View validation package was not found."
+          }
+          $pkg | Format-List Name, PackageFullName, PackageFamilyName, InstallLocation, Status |
+            Out-File "artifacts\validation\installed-package.txt"
+
+      - name: Prepare screenshot input images
+        shell: pwsh
+        run: |
+          choco install imagemagick.app --no-progress --yes
+          New-Item -ItemType Directory -Force "artifacts\screenshots\input" | Out-Null
+          $magick = (Get-Command magick.exe -ErrorAction Stop).Source
+          & $magick "docs\images\viewer-video.webp" -crop "960x540+100+108" +repage "artifacts\screenshots\input\reference.png"
+          & $magick "artifacts\screenshots\input\reference.png" -quality 72 "artifacts\screenshots\input\encoded.jpg"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to make screenshot input images."
+          }
+
+      - name: Capture installed application windows
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force "artifacts\screenshots" | Out-Null
+          choco install qres --no-progress --yes
+          $qres = Get-Command QRes.exe -ErrorAction SilentlyContinue
+          if ($qres) {
+            & $qres.Source /x:1920 /y:1080
+          }
+
+          Add-Type -AssemblyName System.Drawing
+          Add-Type -AssemblyName System.Windows.Forms
+          Add-Type @"
+          using System;
+          using System.Runtime.InteropServices;
+          public static class Q1WindowTools {
+              [DllImport("user32.dll")]
+              public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
+          }
+          "@
+
+          $pkg = Get-AppxPackage -Name "KyuwonKim.Q1View"
+          $reference = (Resolve-Path "artifacts\screenshots\input\reference.png").Path
+          $encoded = (Resolve-Path "artifacts\screenshots\input\encoded.jpg").Path
+
+          function Capture-AppWindow([string]$exeName, [string]$arguments, [string]$destination) {
+            $exePath = Join-Path $pkg.InstallLocation $exeName
+            $process = Start-Process -FilePath $exePath -ArgumentList $arguments -PassThru
+            try {
+              foreach ($attempt in 1..20) {
+                Start-Sleep -Milliseconds 500
+                $process.Refresh()
+                if ($process.HasExited) {
+                  throw "$exeName exited before its window could be captured."
+                }
+                if ($process.MainWindowHandle -ne 0) {
+                  break
+                }
+              }
+              if ($process.MainWindowHandle -eq 0) {
+                throw "No visible window was created for $exeName."
+              }
+              [Q1WindowTools]::ShowWindowAsync($process.MainWindowHandle, 3) | Out-Null
+              Start-Sleep -Seconds 3
+
+              $bounds = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+              "$exeName primary screen: $($bounds.Width)x$($bounds.Height)" |
+                Out-File "artifacts\screenshots\display.txt" -Append
+              if ($bounds.Width -lt 1366 -or $bounds.Height -lt 768) {
+                throw "Screen resolution $($bounds.Width)x$($bounds.Height) is below Store screenshot minimum."
+              }
+              $bitmap = New-Object System.Drawing.Bitmap($bounds.Width, $bounds.Height)
+              $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+              try {
+                $graphics.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+                $bitmap.Save($destination, [System.Drawing.Imaging.ImageFormat]::Png)
+              }
+              finally {
+                $graphics.Dispose()
+                $bitmap.Dispose()
+              }
+            }
+            finally {
+              if (-not $process.HasExited) {
+                Stop-Process -Id $process.Id -Force
+              }
+            }
+          }
+
+          Capture-AppWindow "Viewer.exe" "`"$reference`"" "artifacts\screenshots\viewer.png"
+          Capture-AppWindow "Comparer.exe" "`"$reference|$encoded`"" "artifacts\screenshots\comparer.png"
+
+      - name: Uninstall smoke-tested package
+        shell: pwsh
+        run: |
+          $pkg = Get-AppxPackage -Name "KyuwonKim.Q1View"
+          if (-not $pkg) {
+            throw "Q1View package disappeared before uninstall testing."
+          }
+          Remove-AppxPackage -Package $pkg.PackageFullName
+          if (Get-AppxPackage -Name "KyuwonKim.Q1View") {
+            throw "Q1View package was still installed after Remove-AppxPackage."
+          }
+          "Package installed and uninstalled cleanly." |
+            Out-File "artifacts\validation\install-uninstall-result.txt"
+
+      - name: Run Windows App Certification Kit
+        continue-on-error: true
+        timeout-minutes: 30
+        shell: pwsh
+        run: |
+          $appCert = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\App Certification Kit" `
+            -Filter appcert.exe -Recurse -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if (-not $appCert) {
+            throw "appcert.exe was not found on the Windows runner."
+          }
+          "Using WACK: $($appCert.FullName)" | Out-File "artifacts\validation\wack-command.txt"
+          & $appCert.FullName reset
+          & $appCert.FullName test `
+            -appxpackagepath (Resolve-Path "artifacts\validation\Q1View-validation.msix").Path `
+            -reportoutputpath (Join-Path $PWD "artifacts\validation\WACKReport.xml")
+          if ($LASTEXITCODE -ne 0) {
+            throw "WACK failed with exit code $LASTEXITCODE. See WACKReport.xml."
+          }
+
+      - name: Upload validation output
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: Q1View-store-validation-trial
+          path: artifacts/

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -104,8 +104,7 @@ jobs:
             throw "Failed to make screenshot input images."
           }
 
-      - name: Capture installed application windows
-        continue-on-error: true
+      - name: Capture packaged-build application windows
         shell: powershell
         run: |
           New-Item -ItemType Directory -Force "artifacts\screenshots" | Out-Null
@@ -123,42 +122,14 @@ jobs:
               [DllImport("user32.dll")]
               public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow);
           }
-
-          [ComImport, Guid("2e941141-7f97-4756-ba1a-9decde894a3d"),
-           InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-          interface IApplicationActivationManager {
-              [PreserveSig]
-              int ActivateApplication(
-                  [In, MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
-                  [In, MarshalAs(UnmanagedType.LPWStr)] string arguments,
-                  [In] uint options,
-                  [Out] out uint processId);
-          }
-
-          [ComImport, Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C")]
-          class ApplicationActivationManager {
-          }
-
-          public static class Q1AppLauncher {
-              public static int Launch(string appUserModelId, string arguments) {
-                  IApplicationActivationManager manager =
-                      (IApplicationActivationManager)new ApplicationActivationManager();
-                  uint processId;
-                  int result = manager.ActivateApplication(appUserModelId, arguments, 0, out processId);
-                  Marshal.ThrowExceptionForHR(result);
-                  return (int)processId;
-              }
-          }
           "@
 
-          $pkg = Get-AppxPackage -Name "KyuwonKim.Q1View"
           $reference = (Resolve-Path "artifacts\screenshots\input\reference.png").Path
           $encoded = (Resolve-Path "artifacts\screenshots\input\encoded.jpg").Path
 
           function Capture-AppWindow([string]$appId, [string]$arguments, [string]$destination) {
-            $appUserModelId = "$($pkg.PackageFamilyName)!$appId"
-            $processId = [Q1AppLauncher]::Launch($appUserModelId, $arguments)
-            $process = Get-Process -Id $processId -ErrorAction Stop
+            $exePath = Join-Path $env:DIST_DIR "$appId.exe"
+            $process = Start-Process -FilePath $exePath -ArgumentList $arguments -PassThru
             try {
               foreach ($attempt in 1..20) {
                 Start-Sleep -Milliseconds 500
@@ -222,7 +193,6 @@ jobs:
             Out-File "artifacts\validation\install-uninstall-result.txt"
 
       - name: Run Windows App Certification Kit
-        continue-on-error: true
         timeout-minutes: 30
         shell: pwsh
         run: |
@@ -246,4 +216,11 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: Q1View-store-validation-trial
-          path: artifacts/
+          path: |
+            artifacts/store-submission/
+            artifacts/screenshots/
+            artifacts/validation/WACKReport.xml
+            artifacts/validation/signature.txt
+            artifacts/validation/installed-package.txt
+            artifacts/validation/install-uninstall-result.txt
+            artifacts/validation/wack-command.txt

--- a/.github/workflows/store-validation-trial.yml
+++ b/.github/workflows/store-validation-trial.yml
@@ -204,7 +204,8 @@ jobs:
             if ($viewerProcess.MainWindowHandle -eq 0) {
               throw "Viewer did not create a window for its Compare action test."
             }
-            [Q1WindowTools]::SendMessage($viewerProcess.MainWindowHandle, 0x0111, [UIntPtr]32771, [IntPtr]::Zero) | Out-Null
+            $compareCommand = [UIntPtr]::new([uint32]32771)
+            [Q1WindowTools]::SendMessage($viewerProcess.MainWindowHandle, 0x0111, $compareCommand, [IntPtr]::Zero) | Out-Null
             foreach ($attempt in 1..20) {
               Start-Sleep -Milliseconds 500
               $comparerProcess = Get-Process -Name "Comparer" -ErrorAction SilentlyContinue |

--- a/Comparer/Comparer.cpp
+++ b/Comparer/Comparer.cpp
@@ -35,9 +35,14 @@ class CComparerCommandLineInfo : public CCommandLineInfo
 public:
 	virtual void ParseParam(const TCHAR* pszParam, BOOL bFlag, BOOL bLast)
 	{
-		if (!bFlag && m_nShellCommand == FileOpen && !m_strFileName.IsEmpty()) {
+		if (!bFlag && !m_strFileName.IsEmpty() &&
+			(m_nShellCommand == FileNew || m_nShellCommand == FileOpen)) {
 			m_strFileName += CSV_SEPARATOR;
 			m_strFileName += pszParam;
+			if (bLast) {
+				m_nShellCommand = FileOpen;
+				m_bShowSplash = FALSE;
+			}
 			return;
 		}
 

--- a/Comparer/Comparer.cpp
+++ b/Comparer/Comparer.cpp
@@ -33,14 +33,19 @@ CComparerApp theApp;
 class CComparerCommandLineInfo : public CCommandLineInfo
 {
 public:
+	CString m_strFilesToOpen;
+
 	virtual void ParseParam(const TCHAR* pszParam, BOOL bFlag, BOOL bLast)
 	{
-		if (!bFlag && !m_strFileName.IsEmpty() &&
-			(m_nShellCommand == FileNew || m_nShellCommand == FileOpen)) {
-			m_strFileName += CSV_SEPARATOR;
-			m_strFileName += pszParam;
+		if (!bFlag && (m_nShellCommand == FileNew || !m_strFilesToOpen.IsEmpty())) {
+			if (!m_strFilesToOpen.IsEmpty())
+				m_strFilesToOpen += CSV_SEPARATOR;
+			m_strFilesToOpen += pszParam;
+
 			if (bLast) {
-				m_nShellCommand = FileOpen;
+				// Let MFC create the SDI frame without treating a multi-file
+				// list as one shell/MRU path. The app opens these files below.
+				m_nShellCommand = FileNew;
 				m_bShowSplash = FALSE;
 			}
 			return;
@@ -87,6 +92,17 @@ BOOL CComparerApp::InitInstance()
 	// The one and only window has been initialized, so show and update it
 	m_pMainWnd->ShowWindow(SW_SHOW);
 	m_pMainWnd->UpdateWindow();
+
+	if (!cmdInfo.m_strFilesToOpen.IsEmpty()) {
+		CMainFrame *pMainFrm = static_cast<CMainFrame *>(m_pMainWnd);
+		CComparerDoc *pDoc = static_cast<CComparerDoc *>(pMainFrm->GetActiveDocument());
+		if (pDoc == NULL)
+			return FALSE;
+
+		pDoc->mPendingFile = cmdInfo.m_strFilesToOpen;
+		pMainFrm->PostMessage(WM_OPEN_PENDING_FILE);
+	}
+
 	// call DragAcceptFiles only if there's a suffix
 	//  In an SDI app, this should occur after ProcessShellCommand
 	return TRUE;

--- a/Comparer/Comparer.cpp
+++ b/Comparer/Comparer.cpp
@@ -30,6 +30,21 @@ CComparerApp::CComparerApp()
 
 CComparerApp theApp;
 
+class CComparerCommandLineInfo : public CCommandLineInfo
+{
+public:
+	virtual void ParseParam(const TCHAR* pszParam, BOOL bFlag, BOOL bLast)
+	{
+		if (!bFlag && m_nShellCommand == FileOpen && !m_strFileName.IsEmpty()) {
+			m_strFileName += CSV_SEPARATOR;
+			m_strFileName += pszParam;
+			return;
+		}
+
+		CCommandLineInfo::ParseParam(pszParam, bFlag, bLast);
+	}
+};
+
 
 // CComparerApp initialization
 
@@ -55,7 +70,7 @@ BOOL CComparerApp::InitInstance()
 
 
 	// Parse command line for standard shell commands, DDE, file open
-	CCommandLineInfo cmdInfo;
+	CComparerCommandLineInfo cmdInfo;
 	ParseCommandLine(cmdInfo);
 
 

--- a/Comparer/ComparerDoc.cpp
+++ b/Comparer/ComparerDoc.cpp
@@ -43,6 +43,8 @@ CComparerDoc::CComparerDoc()
 , mD(0.f)
 , mN(ZOOM_RATIO(mD))
 , mFrmState("")
+, mPosInfoView(NULL)
+, mFrmsInfoView(NULL)
 , mMaxFrames(0)
 , mMinFrames(0)
 , mFrmCmpStrategy(NULL)
@@ -519,11 +521,14 @@ BOOL CComparerDoc::OnOpenDocument(LPCTSTR lpszPathName)
 	CMainFrame *pMainFrm = static_cast<CMainFrame *>(AfxGetMainWnd());
 	CString fileList = lpszPathName == NULL ? _T("") : lpszPathName;
 
-	if (pMainFrm == NULL) {
-		// Command-line open can reach here before the SDI frame exists.
-		// Defer the real open until CMainFrame::ActivateFrame().
+	if (pMainFrm == NULL || !pMainFrm->IsWindowVisible()) {
+		// A startup shell-open can run before the frame views have received
+		// their initial layout. Delay loading until there is a drawable pane.
 		mPendingFile = fileList;
-		::CoInitialize(NULL);
+		if (pMainFrm == NULL)
+			::CoInitialize(NULL);
+		else
+			pMainFrm->PostMessage(WM_OPEN_PENDING_FILE);
 		return TRUE;
 	}
 

--- a/Comparer/ComparerView.cpp
+++ b/Comparer/ComparerView.cpp
@@ -19,7 +19,13 @@
 // CComparerView
 
 CComparerView::CComparerView()
-: mIsClicked(false)
+: mXDst(0)
+, mYDst(0)
+, mWClient(0)
+, mHClient(0)
+, mWCanvas(0)
+, mHCanvas(0)
+, mIsClicked(false)
 , mProcessing(false)
 , mRgbBufSize(0)
 , mRgbBuf(NULL)

--- a/Comparer/MainFrm.cpp
+++ b/Comparer/MainFrm.cpp
@@ -657,8 +657,16 @@ LRESULT CMainFrame::OnOpenPendingFile(WPARAM, LPARAM)
 	if (pDoc == NULL || pDoc->mPendingFile.IsEmpty())
 		return 0;
 
-	// Wait until startup activation and layout messages have completed before a
-	// multi-source open starts metric calculation and the scan worker.
+	CComparerView *firstView = pDoc->mPane[CComparerDoc::IMG_VIEW_1].pView;
+	if (!IsWindowVisible() || pDoc->mPosInfoView == NULL ||
+		pDoc->mFrmsInfoView == NULL || firstView == NULL ||
+		firstView->mWCanvas <= 0 || firstView->mHCanvas <= 0) {
+		PostMessage(WM_OPEN_PENDING_FILE);
+		return 0;
+	}
+
+	// Multi-source open starts metric calculation and the scan worker; run it
+	// only after the startup frame layout supplies usable view dimensions.
 	CString pendingFile = pDoc->mPendingFile;
 	pDoc->mPendingFile.Empty();
 	pDoc->OnOpenDocument(pendingFile);

--- a/Comparer/MainFrm.cpp
+++ b/Comparer/MainFrm.cpp
@@ -51,6 +51,7 @@ BEGIN_MESSAGE_MAP(CMainFrame, CFrameWnd)
 	ON_WM_TIMER()
 	ON_WM_DESTROY()
 	ON_WM_CREATE()
+	ON_MESSAGE(WM_OPEN_PENDING_FILE, &CMainFrame::OnOpenPendingFile)
 END_MESSAGE_MAP()
 
 CMainFrame::CMainFrame()
@@ -646,8 +647,21 @@ void CMainFrame::ActivateFrame(int nCmdShow)
 	CFrameWnd::ActivateFrame(nCmdShow);
 
 	CComparerDoc *pDoc = static_cast<CComparerDoc *>(GetActiveDocument());
-	if (pDoc->mPendingFile != "") {
-		pDoc->OnOpenDocument(pDoc->mPendingFile);
-		pDoc->mPendingFile = "";
-	}
+	if (pDoc != NULL && !pDoc->mPendingFile.IsEmpty())
+		PostMessage(WM_OPEN_PENDING_FILE);
+}
+
+LRESULT CMainFrame::OnOpenPendingFile(WPARAM, LPARAM)
+{
+	CComparerDoc *pDoc = static_cast<CComparerDoc *>(GetActiveDocument());
+	if (pDoc == NULL || pDoc->mPendingFile.IsEmpty())
+		return 0;
+
+	// Wait until startup activation and layout messages have completed before a
+	// multi-source open starts metric calculation and the scan worker.
+	CString pendingFile = pDoc->mPendingFile;
+	pDoc->mPendingFile.Empty();
+	pDoc->OnOpenDocument(pendingFile);
+
+	return 0;
 }

--- a/Comparer/MainFrm.h
+++ b/Comparer/MainFrm.h
@@ -13,6 +13,8 @@
 #define FRAMES_INFO_H         84
 #define POS_INFO_W            76
 
+#define WM_OPEN_PENDING_FILE  (WM_APP + 1)
+
 #define COMPARER_DEF_W        (CANVAS_DEF_W + /* left */ \
                               (CANVAS_DEF_W + QSPLITTER_W) + /* right */ \
                               (POS_INFO_W + QSPLITTER_W)) /* position */
@@ -98,6 +100,7 @@ public:
 	afx_msg void OnFpsChange(UINT nID);
 	afx_msg void OnViewsChange(UINT nID);
 	afx_msg void OnOptionsChange(UINT nID);
+	afx_msg LRESULT OnOpenPendingFile(WPARAM wParam, LPARAM lParam);
 	virtual void ActivateFrame(int nCmdShow = -1);
 };
 

--- a/Viewer/MainFrm.cpp
+++ b/Viewer/MainFrm.cpp
@@ -632,31 +632,40 @@ LRESULT CMainFrame::OnApplySyncViewState(WPARAM wParam, LPARAM lParam)
 
 void CMainFrame::OnExecComparer()
 {
-	TCHAR curDir[MAX_PATH];
-	::GetCurrentDirectory(MAX_PATH, curDir);
-
+	TCHAR viewerPath[MAX_PATH] = {0, };
 	CString cmperPath;
 	BOOL cmperExists;
 	STARTUPINFO startUpInfo = {0, };
 	PROCESS_INFORMATION processInfo = {0, };
 	startUpInfo.cb = sizeof(STARTUPINFO);
 
-	cmperPath = curDir;
+	DWORD viewerPathLength = ::GetModuleFileName(NULL, viewerPath, _countof(viewerPath));
+	if (viewerPathLength == 0 || viewerPathLength >= _countof(viewerPath) ||
+			!::PathRemoveFileSpec(viewerPath)) {
+		MessageBox(_T("Couldn't determine the Viewer installation directory."),
+			_T("Warning"), MB_ICONWARNING);
+		return;
+	}
+
+	cmperPath = viewerPath;
 	cmperPath += _T("\\Comparer.exe");
 
 	cmperExists = ::PathFileExists(cmperPath);
 
 #ifdef _DEBUG
 	if (!cmperExists) {
-		cmperPath = curDir;
-		cmperPath += _T("\\..\\Comparer\\x64\\Debug\\Comparer.exe");
+		TCHAR curDir[MAX_PATH] = {0, };
+		if (::GetCurrentDirectory(_countof(curDir), curDir) != 0) {
+			cmperPath = curDir;
+			cmperPath += _T("\\..\\Comparer\\x64\\Debug\\Comparer.exe");
 
-		cmperExists = ::PathFileExists(cmperPath);
+			cmperExists = ::PathFileExists(cmperPath);
+		}
 	}
 #endif
 
 	if (!cmperExists) {
-		MessageBox(_T("Coundn't find the 'Comparer.exe'"), _T("Warning"), MB_ICONWARNING);
+		MessageBox(_T("Couldn't find 'Comparer.exe' next to Viewer.exe."), _T("Warning"), MB_ICONWARNING);
 		return;
 	}
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -105,9 +105,11 @@ To validate the manifest without signing:
 
 ### Manifest
 
-`installer/msix/AppxManifest.xml` defines the package identity, both
-application entry points (Viewer and Comparer), and the `runFullTrust`
-capability required for unpackaged Win32 applications.
+`installer/msix/AppxManifest.xml` defines the package identity, the Viewer
+application entry point, and the `runFullTrust` capability required for
+packaged Win32 applications. `Comparer.exe` remains in the MSIX payload and
+is launched through Viewer's **Compare** action; declaring it as a second
+Store entry point fails WACK package compliance.
 
 Before Store submission, update `Identity/@Publisher` to match the exact
 Publisher string shown in Microsoft Partner Center. The `Version` and

--- a/docs/STORE_LISTING.md
+++ b/docs/STORE_LISTING.md
@@ -54,7 +54,7 @@ TECHNICAL NOTES
 • Windows x64 only
 • Korean and Unicode file and folder names are supported
 • No internet connection required; no data is collected or transmitted
-• Installer registers separate Start Menu entries for Viewer and Comparer
+• The Store app launches its dedicated Comparer workflow directly from Viewer
 • Portable ZIP available for use without installation
 ```
 
@@ -73,7 +73,7 @@ TECHNICAL NOTES
 8. Frame sequence navigation through same-folder images
 9. Clipboard paste and screen capture support
 10. Unicode and Korean path support
-11. Separate Viewer and Comparer applications, each with a Start Menu entry
+11. Launch the dedicated Comparer workflow directly from Viewer
 12. Step through video frames one at a time with Left/Right arrow keys
 13. Rotation, luma-only view, interpolation, and hex pixel value modes
 14. Allow Different Resolution mode for cross-resolution comparisons

--- a/docs/STORE_SUBMISSION.md
+++ b/docs/STORE_SUBMISSION.md
@@ -15,7 +15,7 @@ Before starting a submission, confirm the following are ready:
 | Logo assets (all required sizes) | Required | See `installer/msix/Assets/README.md` |
 | Privacy Policy URL | Ready | `https://github.com/chammoru/Q1View/blob/master/PRIVACY.md` |
 | Store listing text | Ready | See `docs/STORE_LISTING.md` |
-| Store screenshots | Required | At least 1 per app; see [Screenshots](#screenshots) below |
+| Store screenshots | Required | Show both Viewer and Comparer workflows; see [Screenshots](#screenshots) below |
 
 ## MSIX Packaging
 
@@ -44,7 +44,7 @@ The signed package is written to `dist\Q1View-windows-x64.msix`.
 # Install (sideload)
 Add-AppPackage -Path .\dist\Q1View-windows-x64.msix
 
-# Verify both apps launch and operate correctly, then uninstall
+# Verify Viewer launches and its Compare action opens Comparer, then uninstall
 Get-AppPackage -Name "KyuwonKim.Q1View" | Remove-AppPackage
 ```
 
@@ -108,7 +108,10 @@ Use the text from `docs/STORE_LISTING.md`:
 
 ### 5. Screenshots
 
-At minimum, provide one screenshot per application. Recommended set:
+At minimum, provide screenshots that show the Viewer and Comparer workflows.
+The Store package exposes Viewer as its single entry point; Comparer is
+included in the package and launched from Viewer's **Compare** action.
+Recommended set:
 
 | Screenshot | Resolution | Content |
 | --- | --- | --- |
@@ -126,7 +129,7 @@ Accepted sizes: 1366×768 minimum, 3840×2160 maximum. PNG or JPEG.
 - [ ] Confirm package details in Partner Center match the manifest:
   - Publisher CN matches certificate
   - Version matches the release tag (e.g. `1.0.16.0`)
-  - Both Viewer and Comparer appear as separate entry points
+  - Viewer appears as the Store entry point and can launch the included Comparer workflow
 
 ### 7. Final review and submit
 

--- a/installer/msix/AppxManifest.xml
+++ b/installer/msix/AppxManifest.xml
@@ -64,22 +64,6 @@
       </uap:VisualElements>
     </Application>
 
-    <Application
-      Id="Comparer"
-      Executable="Comparer.exe"
-      EntryPoint="Windows.FullTrustApplication">
-      <uap:VisualElements
-        DisplayName="Q1View Comparer"
-        Description="Compare image and video sources side by side with PSNR and SSIM metrics."
-        BackgroundColor="transparent"
-        Square150x150Logo="Assets\Square150x150Logo.png"
-        Square44x44Logo="Assets\Square44x44Logo.png">
-        <uap:DefaultTile
-          Wide310x150Logo="Assets\Wide310x150Logo.png"
-          ShortName="Comparer" />
-      </uap:VisualElements>
-    </Application>
-
   </Applications>
 
   <Capabilities>


### PR DESCRIPTION
## Summary
- fix Comparer startup when invoked with multiple command-line file paths
- expose one Viewer entry point in the Store MSIX while retaining the bundled Comparer workflow
- make Viewer locate bundled Comparer relative to its installed executable
- add a Windows Store validation workflow that builds the MSIX, smoke-tests install/uninstall, captures screenshots, and runs WACK

## Validation
- Successful Windows 2022 run: https://github.com/chammoru/Q1View/actions/runs/26398002142
- Comparer remained running after opening `reference.png` and `encoded.jpg` from the command line
- Viewer launched bundled Comparer while running from a different working directory
- MSIX installed and uninstalled cleanly
- WACK `Application count` now passes after using a single Store entry point
- WACK overall result is `WARNING`: `Blocked executables` is an optional Desktop Bridge test and `DPIAwarenessValidation` reports a warning

Microsoft documents Desktop Bridge optional tests as informational and not used to evaluate Store onboarding: https://learn.microsoft.com/en-us/windows/uwp/debug-test-perf/windows-desktop-bridge-app-tests

Fixes #16
Relates to #27