### PR TITLE
Comparer: auto-refresh panes when source files change (#18)

### DIFF
--- a/Comparer/Comparer.vcxproj
+++ b/Comparer/Comparer.vcxproj
@@ -214,6 +214,7 @@
     <ClCompile Include="ComparerViews.cpp" />
     <ClCompile Include="CustomFpsDlg.cpp" />
     <ClCompile Include="CustomSizeDlg.cpp" />
+    <ClCompile Include="FileChangeNotiThread.cpp" />
     <ClCompile Include="FileScanThread.cpp" />
     <ClCompile Include="FrmCmpStrategy.cpp" />
     <ClCompile Include="FrmInfoView.cpp" />
@@ -245,6 +246,7 @@
     <ClInclude Include="ComparerViews.h" />
     <ClInclude Include="CustomFpsDlg.h" />
     <ClInclude Include="CustomSizeDlg.h" />
+    <ClInclude Include="FileChangeNotiThread.h" />
     <ClInclude Include="FileScanThread.h" />
     <ClInclude Include="FrmCmpInfo.h" />
     <ClInclude Include="FrmCmpStrategy.h" />

--- a/Comparer/ComparerDoc.cpp
+++ b/Comparer/ComparerDoc.cpp
@@ -15,6 +15,7 @@
 #include "MetricCal.h"
 #include "QViewerCmn.h"
 #include "ComparerUtil.h"
+#include "FileChangeNotiThread.h"
 
 #include "QImageStr.h"
 
@@ -76,6 +77,8 @@ CComparerDoc::CComparerDoc()
 	bmiHeader.biYPelsPerMeter = 0L;
 
 	mFileScanThread = new FileScanThread(this);
+	for (int i = 0; i < IMG_VIEW_MAX; i++)
+		mFileChangeNotiThreads[i] = new FileChangeNotiThread();
 
 	mSortedCscInfo =
 		static_cast<struct qcsc_info *>(malloc(sizeof(qcsc_info_table)));
@@ -87,6 +90,11 @@ CComparerDoc::CComparerDoc()
 CComparerDoc::~CComparerDoc()
 {
 	mFileScanThread->requestExitAndWait();
+
+	for (int i = 0; i < IMG_VIEW_MAX; i++) {
+		delete mFileChangeNotiThreads[i];
+		mFileChangeNotiThreads[i] = NULL;
+	}
 
 	delete [] mPane;
 
@@ -375,6 +383,40 @@ void CComparerDoc::ProcessDocument(ComparerPane *pane)
 	pView->UpdateFileName(fileName);
 
 	RefleshPaneImages(pane, settingChanged);
+
+	// Start (or rebind) the file-change watcher for this pane so disk edits
+	// trigger a refresh.
+	int paneIdx = static_cast<int>(pane - mPane);
+	if (paneIdx >= 0 && paneIdx < IMG_VIEW_MAX && mFileChangeNotiThreads[paneIdx]) {
+		CMainFrame *pMainFrm = static_cast<CMainFrame *>(AfxGetMainWnd());
+		mFileChangeNotiThreads[paneIdx]->fire(pMainFrm, pane->pathName, paneIdx);
+	}
+}
+
+void CComparerDoc::ReloadPane(int paneIdx)
+{
+	if (paneIdx < 0 || paneIdx >= IMG_VIEW_MAX)
+		return;
+	ComparerPane *pane = &mPane[paneIdx];
+	if (!pane->isAvail() || pane->pathName.IsEmpty())
+		return;
+
+	// Re-read the current frame from disk. ProcessDocument handles a possible
+	// resolution / color-space change after the file was rewritten.
+	ProcessDocument(pane);
+
+	// Recompute metrics between the active pair so the pixel-diff overlay,
+	// PSNR/SSIM, and any visible labels reflect the new contents.
+	if (mFrmCmpStrategy) {
+		ComparerPane *paneL = &mPane[IMG_VIEW_1];
+		ComparerPane *paneR = &mPane[IMG_VIEW_2];
+		CMainFrame *pMainFrm = static_cast<CMainFrame *>(AfxGetMainWnd());
+		if (paneL->isAvail() && paneR->isAvail())
+			mFrmCmpStrategy->CalMetrics(paneL, paneR,
+				pMainFrm->mMetricIdx, mFrmState);
+	}
+
+	UpdateAllViews(NULL);
 }
 
 void CComparerDoc::ViewOnMouseWheel(short zDelta, int wCanvas, int hCanvas)

--- a/Comparer/ComparerDoc.h
+++ b/Comparer/ComparerDoc.h
@@ -62,6 +62,7 @@ public:
 	CFrmsInfoView *mFrmsInfoView;
 	int mMaxFrames, mMinFrames;
 	FileScanThread *mFileScanThread;
+	class FileChangeNotiThread *mFileChangeNotiThreads[IMG_VIEW_MAX];
 	IFrmCmpStrategy *mFrmCmpStrategy;
 	YuvFrmCmpStrategy *mYuvCompare;
 	RgbFrmCmpStrategy *mRgbCompare;
@@ -86,6 +87,7 @@ public:
 	void ProcessDocument(ComparerPane *pane);
 	void LoadSourceImage(ComparerPane *pane);
 	bool ReadSource4View(ComparerPane *pane);
+	void ReloadPane(int paneIdx);
 	bool IsRGBCompare(const SQPane *paneA, const SQPane *paneB) const;
 	void RefleshPaneImages(ComparerPane *pane, bool settingChanged);
 	inline ComparerPane* GetOppositePane(ComparerPane* pane) {

--- a/Comparer/FileChangeNotiThread.cpp
+++ b/Comparer/FileChangeNotiThread.cpp
@@ -1,0 +1,141 @@
+#include "stdafx.h"
+#include "FileChangeNotiThread.h"
+#include <QDebug.h>
+
+FileChangeNotiThread::FileChangeNotiThread()
+: mChangeHandle(INVALID_HANDLE_VALUE)
+, mNotifyHwnd(NULL)
+, mDirName("")
+, mFileName("")
+, mPaneIdx(-1)
+{
+}
+
+FileChangeNotiThread::~FileChangeNotiThread(void)
+{
+	cleanUp();
+}
+
+void FileChangeNotiThread::cleanUp()
+{
+	requestExit();
+
+	HANDLE changeHandle = INVALID_HANDLE_VALUE;
+	{
+		SMutex::Autolock lock(mStateLock);
+		changeHandle = mChangeHandle;
+		mChangeHandle = INVALID_HANDLE_VALUE;
+	}
+
+	if (changeHandle != INVALID_HANDLE_VALUE) {
+		::CancelIoEx(changeHandle, NULL);
+		::CloseHandle(changeHandle);
+	}
+
+	requestExitAndWait();
+}
+
+SmpError FileChangeNotiThread::fire(CMainFrame *pFrame, CString pathName, int paneIdx)
+{
+	CString oldDirName;
+	{
+		SMutex::Autolock lock(mStateLock);
+		oldDirName = mDirName;
+	}
+
+	CString newDirName = pathName.Left(pathName.ReverseFind('\\') + 1);
+	CString newFileName = pathName.Mid(pathName.ReverseFind('\\') + 1);
+	HWND notifyHwnd = pFrame != NULL ? pFrame->GetSafeHwnd() : NULL;
+
+	if (oldDirName != newDirName) {
+		cleanUp();
+
+		HANDLE changeHandle = ::CreateFile(newDirName, FILE_LIST_DIRECTORY,
+			FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+			NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+		if (changeHandle == INVALID_HANDLE_VALUE) {
+			LOGERR("mChangeHandle is invalid");
+			return SMP_INVALID_RESOURCE;
+		}
+
+		{
+			SMutex::Autolock lock(mStateLock);
+			mNotifyHwnd = notifyHwnd;
+			mDirName = newDirName;
+			mFileName = newFileName;
+			mPaneIdx = paneIdx;
+			mChangeHandle = changeHandle;
+		}
+
+		SmpError err = run();
+		if (err != SMP_OK) {
+			{
+				SMutex::Autolock lock(mStateLock);
+				changeHandle = mChangeHandle;
+				mChangeHandle = INVALID_HANDLE_VALUE;
+			}
+			::CloseHandle(changeHandle);
+			LOGWRN("failed to run FileChangeNotiThread [%d]", err);
+			return err;
+		}
+	} else {
+		SMutex::Autolock lock(mStateLock);
+		mNotifyHwnd = notifyHwnd;
+		mFileName = newFileName;
+		mPaneIdx = paneIdx;
+	}
+
+	return SMP_OK;
+}
+
+bool FileChangeNotiThread::threadLoop()
+{
+	HANDLE changeHandle = INVALID_HANDLE_VALUE;
+	{
+		SMutex::Autolock lock(mStateLock);
+		changeHandle = mChangeHandle;
+	}
+	if (changeHandle == INVALID_HANDLE_VALUE)
+		return false;
+
+	DWORD dwBytesReturned = 0;
+	const DWORD dwBuffLength = 4096;
+	BYTE buffer[dwBuffLength];
+	BOOL ok = ::ReadDirectoryChangesW(changeHandle, buffer, dwBuffLength, FALSE,
+		FILE_NOTIFY_CHANGE_LAST_WRITE, &dwBytesReturned, NULL, NULL);
+	if (!ok || exitPending())
+		return false;
+
+	HWND notifyHwnd = NULL;
+	CString watchedFileName;
+	int paneIdx = -1;
+	{
+		SMutex::Autolock lock(mStateLock);
+		notifyHwnd = mNotifyHwnd;
+		watchedFileName = mFileName;
+		paneIdx = mPaneIdx;
+	}
+
+	DWORD dwNextEntryOffset = 0;
+	PFILE_NOTIFY_INFORMATION pfni;
+	do {
+		pfni = PFILE_NOTIFY_INFORMATION(buffer + dwNextEntryOffset);
+		switch (pfni->Action) {
+		case FILE_ACTION_MODIFIED:
+		{
+			CString changedFileName(pfni->FileName,
+				static_cast<int>(pfni->FileNameLength / sizeof(WCHAR)));
+			if (watchedFileName == changedFileName && notifyHwnd != NULL)
+				::PostMessage(notifyHwnd, WM_RELOAD_PANE,
+					static_cast<WPARAM>(paneIdx), 0);
+			break;
+		}
+		default:
+			LOGERR("Unhandled: System Error Code [%d]", GetLastError());
+			break;
+		}
+		dwNextEntryOffset += pfni->NextEntryOffset;
+	} while (pfni && pfni->NextEntryOffset != 0);
+
+	return true;
+}

--- a/Comparer/FileChangeNotiThread.h
+++ b/Comparer/FileChangeNotiThread.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <SThread.h>
+#include <SMutex.h>
+#include "MainFrm.h"
+
+// Watches one file on disk and, when it is modified, posts WM_RELOAD_PANE to
+// the supplied frame with the pane index in WPARAM. One instance per pane.
+class FileChangeNotiThread : public SThread
+{
+public:
+	FileChangeNotiThread();
+	virtual ~FileChangeNotiThread(void);
+	SmpError fire(CMainFrame *pFrame, CString pathName, int paneIdx);
+
+private:
+	int requestExitAndWait() { // do not call from outside, setup() will do
+		return SThread::requestExitAndWait();
+	}
+
+	virtual SmpError run(const char* name = 0,
+		int priority = STHREAD_PRIORITY_DEFAULT,
+		int stack = 0) {
+		return SThread::run();
+	}
+
+	virtual bool threadLoop();
+	void cleanUp();
+
+	HANDLE mChangeHandle;
+	HWND mNotifyHwnd;
+	CString mDirName;
+	CString mFileName;
+	int mPaneIdx;
+	SMutex mStateLock;
+};

--- a/Comparer/MainFrm.cpp
+++ b/Comparer/MainFrm.cpp
@@ -52,6 +52,7 @@ BEGIN_MESSAGE_MAP(CMainFrame, CFrameWnd)
 	ON_WM_DESTROY()
 	ON_WM_CREATE()
 	ON_MESSAGE(WM_OPEN_PENDING_FILE, &CMainFrame::OnOpenPendingFile)
+	ON_MESSAGE(WM_RELOAD_PANE, &CMainFrame::OnReloadPane)
 END_MESSAGE_MAP()
 
 CMainFrame::CMainFrame()
@@ -671,5 +672,15 @@ LRESULT CMainFrame::OnOpenPendingFile(WPARAM, LPARAM)
 	pDoc->mPendingFile.Empty();
 	pDoc->OnOpenDocument(pendingFile);
 
+	return 0;
+}
+
+LRESULT CMainFrame::OnReloadPane(WPARAM wParam, LPARAM /*lParam*/)
+{
+	CComparerDoc *pDoc = static_cast<CComparerDoc *>(GetActiveDocument());
+	if (pDoc == NULL)
+		return 0;
+
+	pDoc->ReloadPane(static_cast<int>(wParam));
 	return 0;
 }

--- a/Comparer/MainFrm.h
+++ b/Comparer/MainFrm.h
@@ -14,6 +14,7 @@
 #define POS_INFO_W            76
 
 #define WM_OPEN_PENDING_FILE  (WM_APP + 1)
+#define WM_RELOAD_PANE        (WM_USER + 100)
 
 #define COMPARER_DEF_W        (CANVAS_DEF_W + /* left */ \
                               (CANVAS_DEF_W + QSPLITTER_W) + /* right */ \
@@ -101,6 +102,7 @@ public:
 	afx_msg void OnViewsChange(UINT nID);
 	afx_msg void OnOptionsChange(UINT nID);
 	afx_msg LRESULT OnOpenPendingFile(WPARAM wParam, LPARAM lParam);
+	afx_msg LRESULT OnReloadPane(WPARAM wParam, LPARAM lParam);
 	virtual void ActivateFrame(int nCmdShow = -1);
 };
 


### PR DESCRIPTION
Closes #18.

Ports the Viewer file-watcher to Comparer. Each pane owns its own `FileChangeNotiThread` that watches the pane's source file with `ReadDirectoryChangesW`. When the file is modified on disk, the thread posts `WM_RELOAD_PANE` with the pane index; the main frame routes it to `CComparerDoc::ReloadPane`, which re-runs `ProcessDocument` and recomputes metrics for the active pair.

## How to try
- Open a source into each pane.
- Replace one of the source files on disk (e.g. encode again, copy a different file over).
- The affected pane refreshes automatically and the pink diff overlay updates.