### PR TITLE
Comparer: zoom metric graph with the mouse wheel (#17)

### DIFF
--- a/Comparer/FrmsInfoView.cpp
+++ b/Comparer/FrmsInfoView.cpp
@@ -53,6 +53,8 @@ BEGIN_MESSAGE_MAP(CFrmsInfoView, CView)
 	ON_WM_SIZE()
 	ON_WM_CREATE()
 	ON_WM_ERASEBKGND()
+	ON_WM_MOUSEWHEEL()
+	ON_WM_LBUTTONDBLCLK()
 END_MESSAGE_MAP()
 
 
@@ -184,4 +186,28 @@ int CFrmsInfoView::OnCreate(LPCREATESTRUCT lpCreateStruct)
 BOOL CFrmsInfoView::OnEraseBkgnd(CDC* pDC)
 {
 	return TRUE;
+}
+
+BOOL CFrmsInfoView::OnMouseWheel(UINT /*nFlags*/, short zDelta, CPoint pt)
+{
+	// pt is in screen coordinates; convert to client coordinates so we can
+	// check the cursor against the graph area.
+	CPoint client = pt;
+	ScreenToClient(&client);
+	if (!mGraphRect.PtInRect(client))
+		return FALSE;
+
+	int graphX = client.x - mGraphRect.left - GRAPH_IN_MARGIN_L;
+	mPsnrCal->ZoomAtX(zDelta, graphX);
+	Invalidate(FALSE);
+	return TRUE;
+}
+
+void CFrmsInfoView::OnLButtonDblClk(UINT /*nFlags*/, CPoint point)
+{
+	// Double-click anywhere on the graph restores the full-range view.
+	if (mGraphRect.PtInRect(point)) {
+		mPsnrCal->ResetView();
+		Invalidate(FALSE);
+	}
 }

--- a/Comparer/FrmsInfoView.h
+++ b/Comparer/FrmsInfoView.h
@@ -67,6 +67,8 @@ public:
 	afx_msg void OnSize(UINT nType, int cx, int cy);
 	afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);
 	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
+	afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
+	afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
 };
 
 

--- a/Comparer/MetricCal.cpp
+++ b/Comparer/MetricCal.cpp
@@ -18,6 +18,8 @@ MetricCal::MetricCal()
 , mFileScanThread(NULL)
 , mStepCount(0)
 , mFrameIdx(0)
+, mViewStartFrame(0)
+, mViewEndFrame(0)
 , mAvgFont(new Font(&FontFamily(Q1UI_FONT_TEXT), 9))
 , mMetricIdx(METRIC_PSNR_IDX)
 {
@@ -90,7 +92,16 @@ void MetricCal::Setup(CRect *graphRect, int metricIdx)
 {
 	mGraphRect = *graphRect;
 
-	mStepW = getGraphW() / int(mStepCount + 1);
+	// Clamp the view range to the current parsed run. Zoom may have left the
+	// range outside the new bounds after a fresh load or scan progress.
+	if (mViewEndFrame == 0 || mViewEndFrame > mStepCount)
+		mViewEndFrame = mStepCount;
+	if (mViewStartFrame >= mViewEndFrame)
+		mViewStartFrame = 0;
+
+	size_t viewSpan = mViewEndFrame > mViewStartFrame
+		? mViewEndFrame - mViewStartFrame : 1;
+	mStepW = getGraphW() / int(viewSpan + 1);
 	mStepW = max(mStepW, MIN_X_AXIS_STEP_W);
 
 	mShowID.clear();
@@ -126,7 +137,60 @@ void MetricCal::Update(const FileScanThread *fileScanThread, size_t stepCount)
 	mFileScanThread = fileScanThread;
 	mStepCount = stepCount;
 
+	ResetView();
 	Init();
+}
+
+void MetricCal::ResetView()
+{
+	mViewStartFrame = 0;
+	mViewEndFrame = mStepCount;
+}
+
+void MetricCal::ZoomAtX(short zDelta, int graphX)
+{
+	if (mStepCount == 0)
+		return;
+
+	int graphW = getGraphW();
+	if (graphW <= 0)
+		return;
+
+	if (graphX < 0) graphX = 0;
+	if (graphX > graphW) graphX = graphW;
+
+	// Anchor: the frame currently sitting under the cursor pixel.
+	double span = double(mViewEndFrame - mViewStartFrame);
+	if (span <= 0.0)
+		span = double(mStepCount);
+	double cursorFrame = double(mViewStartFrame) + (double(graphX) / graphW) * span;
+
+	// One wheel notch (WHEEL_DELTA == 120) zooms by ~25%.
+	const double kStep = 1.25;
+	double notches = double(zDelta) / 120.0;
+	double factor = pow(kStep, -notches); // zDelta > 0 -> zoom in -> smaller span
+	double newSpan = span * factor;
+
+	// Show at least 10 frames; don't zoom past the full parsed range.
+	const double kMinSpan = 10.0;
+	if (newSpan < kMinSpan)
+		newSpan = kMinSpan;
+	if (newSpan > double(mStepCount))
+		newSpan = double(mStepCount);
+
+	double newStart = cursorFrame - (double(graphX) / graphW) * newSpan;
+	double newEnd = newStart + newSpan;
+	if (newStart < 0.0) { newEnd -= newStart; newStart = 0.0; }
+	if (newEnd > double(mStepCount)) {
+		newStart -= newEnd - double(mStepCount);
+		newEnd = double(mStepCount);
+		if (newStart < 0.0) newStart = 0.0;
+	}
+
+	mViewStartFrame = static_cast<size_t>(newStart);
+	mViewEndFrame   = static_cast<size_t>(newEnd);
+	if (mViewEndFrame <= mViewStartFrame)
+		mViewEndFrame = mViewStartFrame + 1;
 }
 
 void MetricCal::CalMinMaxAccum()
@@ -175,9 +239,11 @@ size_t MetricCal::CalculateCoords(CRect *graphRect, int metricIdx)
 
 	size_t prevID = -1;
 	int graphW = getGraphW();
+	size_t viewSpan = mViewEndFrame > mViewStartFrame
+		? mViewEndFrame - mViewStartFrame : 1;
 
 	for (int i = 0; i < graphW; i += mStepW) {
-		size_t frameID = (i * mStepCount) / graphW;
+		size_t frameID = mViewStartFrame + (size_t(i) * viewSpan) / graphW;
 
 		if (frameID >= mFrameIdx)
 			break;

--- a/Comparer/MetricCal.h
+++ b/Comparer/MetricCal.h
@@ -27,6 +27,11 @@ class MetricCal
 	size_t mStepCount;
 	size_t mFrameIdx;
 
+	// Frame range currently visible on the X axis. Default covers the whole
+	// parsed run; mouse wheel zoom narrows it around the cursor frame.
+	size_t mViewStartFrame;
+	size_t mViewEndFrame;
+
 	list<size_t> mShowID;
 	list<double> mShowVal[QPLANES];
 
@@ -54,6 +59,13 @@ public:
 
 	void Update(const FileScanThread *fileScanThread, size_t stepCount);
 	size_t CalculateCoords(CRect *graphRect, int metricIdx);
+
+	// Zoom the X axis around the frame at |graphX|. |graphX| is in graph-area
+	// pixels (0 == left edge of the drawable graph). zDelta uses the standard
+	// WHEEL_DELTA sign convention.
+	void ZoomAtX(short zDelta, int graphX);
+	// Restore the X axis to cover the full parsed range.
+	void ResetView();
 
 	void DrawCmpResult(CDC* pDC, CFont *font) const;
 	void DrawYLabel(CDC* pDC, CRect *yLabelRect, CFont *font) const;


### PR DESCRIPTION
Closes #17.

- Adds an X-axis view range to `MetricCal` (`mViewStartFrame` / `mViewEndFrame`). Drawing now samples from the visible range instead of always from frame 0 to the last parsed frame.
- `FrmsInfoView::OnMouseWheel` forwards the cursor's X within the graph to `MetricCal::ZoomAtX`, which zooms ~25% per wheel notch and re-anchors the new range so the frame under the cursor stays at the same pixel.
- Double-clicking the graph area resets the view to the full parsed range.
- View resets automatically when a new source is loaded (`Update()` calls `ResetView()`).

## How to try
- Open two video sources, let metrics scan a while.
- Scroll the mouse wheel over the metric graph — it should zoom around the cursor.
- Double-click to return to the overview.