### PR TITLE
Comparer: click metric graph to seek to that frame (#8)

### DIFF
--- a/Comparer/FrmsInfoView.cpp
+++ b/Comparer/FrmsInfoView.cpp
@@ -55,6 +55,7 @@ BEGIN_MESSAGE_MAP(CFrmsInfoView, CView)
 	ON_WM_ERASEBKGND()
 	ON_WM_MOUSEWHEEL()
 	ON_WM_LBUTTONDBLCLK()
+	ON_WM_LBUTTONDOWN()
 END_MESSAGE_MAP()
 
 
@@ -210,4 +211,43 @@ void CFrmsInfoView::OnLButtonDblClk(UINT /*nFlags*/, CPoint point)
 		mPsnrCal->ResetView();
 		Invalidate(FALSE);
 	}
+}
+
+void CFrmsInfoView::OnLButtonDown(UINT nFlags, CPoint point)
+{
+	if (!mGraphRect.PtInRect(point)) {
+		CView::OnLButtonDown(nFlags, point);
+		return;
+	}
+
+	CComparerDoc *pDoc = GetDocument();
+	if (pDoc->mMinFrames <= 0) {
+		CView::OnLButtonDown(nFlags, point);
+		return;
+	}
+
+	int graphX = point.x - mGraphRect.left - GRAPH_IN_MARGIN_L;
+	long frameID = mPsnrCal->FrameAtX(graphX);
+	if (frameID < 0) {
+		CView::OnLButtonDown(nFlags, point);
+		return;
+	}
+
+	pDoc->KillPlayTimer();
+	pDoc->SetScenes(frameID);
+
+	// Refresh the per-frame metric label shown in FrmInfoView for the new
+	// pair of frames.
+	IFrmCmpStrategy *compareStrategy = pDoc->mFrmCmpStrategy;
+	if (compareStrategy) {
+		CMainFrame *pMainFrm = static_cast<CMainFrame *>(AfxGetMainWnd());
+		ComparerPane *paneL = &pDoc->mPane[CComparerDoc::IMG_VIEW_1];
+		ComparerPane *paneR = &pDoc->mPane[CComparerDoc::IMG_VIEW_2];
+		compareStrategy->CalMetrics(paneL, paneR,
+			pMainFrm->mMetricIdx, pDoc->mFrmState);
+	}
+
+	pDoc->UpdateAllViews(NULL);
+
+	CView::OnLButtonDown(nFlags, point);
 }

--- a/Comparer/FrmsInfoView.h
+++ b/Comparer/FrmsInfoView.h
@@ -69,6 +69,7 @@ public:
 	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 	afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
 	afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
+	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 };
 
 

--- a/Comparer/MetricCal.cpp
+++ b/Comparer/MetricCal.cpp
@@ -193,6 +193,29 @@ void MetricCal::ZoomAtX(short zDelta, int graphX)
 		mViewEndFrame = mViewStartFrame + 1;
 }
 
+long MetricCal::FrameAtX(int graphX) const
+{
+	if (mStepCount == 0 || mFrameIdx == 0)
+		return -1;
+	int graphW = getGraphW();
+	if (graphW <= 0)
+		return -1;
+
+	if (graphX < 0)       graphX = 0;
+	if (graphX > graphW)  graphX = graphW;
+
+	size_t viewSpan = mViewEndFrame > mViewStartFrame
+		? mViewEndFrame - mViewStartFrame : 1;
+	long frameID = long(mViewStartFrame)
+		+ long((size_t(graphX) * viewSpan) / size_t(graphW));
+
+	// Clamp to frames that actually have parsed metrics so far.
+	long maxFrame = long(mFrameIdx) - 1;
+	if (frameID > maxFrame) frameID = maxFrame;
+	if (frameID < 0)        frameID = 0;
+	return frameID;
+}
+
 void MetricCal::CalMinMaxAccum()
 {
 	size_t i;

--- a/Comparer/MetricCal.h
+++ b/Comparer/MetricCal.h
@@ -66,6 +66,9 @@ public:
 	void ZoomAtX(short zDelta, int graphX);
 	// Restore the X axis to cover the full parsed range.
 	void ResetView();
+	// Frame index at the given graph-area X pixel under the current view
+	// range. Returns -1 if no data is available.
+	long FrameAtX(int graphX) const;
 
 	void DrawCmpResult(CDC* pDC, CFont *font) const;
 	void DrawYLabel(CDC* pDC, CRect *yLabelRect, CFont *font) const;


### PR DESCRIPTION
Closes #8.

The PSNR/SSIM line graph in `FrmsInfoView` now responds to left-clicks: clicking any point in the graph area calls `SetScenes()` to set both panes to the frame at that X position, then refreshes the per-frame metric label via `CalMetrics()`. The frame is computed against the current view range, so the wheel-zoom and click-to-seek features stack naturally — zoom in to a region of interest and click any point to land exactly on that frame.

- Clicks outside the graph area fall through to the default handler.
- Double-click still resets the view to the full range.
- If a click happens during playback, the play timer is killed first.

## How to try
- Open two video sources, let metric scanning produce a few frames.
- Click any point on the metric graph — both panes jump to that frame.
- Try zooming in first, then clicking for sub-frame-precision seeks.