### PR TITLE
Comparer: highlight current frame with pane-specific color

### DIFF
--- a/Comparer/FrmsInfoView.cpp
+++ b/Comparer/FrmsInfoView.cpp
@@ -55,6 +55,7 @@ BEGIN_MESSAGE_MAP(CFrmsInfoView, CView)
 	ON_WM_ERASEBKGND()
 	ON_WM_MOUSEWHEEL()
 	ON_WM_LBUTTONDBLCLK()
+	ON_WM_LBUTTONDOWN()
 END_MESSAGE_MAP()
 
 
@@ -210,4 +211,43 @@ void CFrmsInfoView::OnLButtonDblClk(UINT /*nFlags*/, CPoint point)
 		mPsnrCal->ResetView();
 		Invalidate(FALSE);
 	}
+}
+
+void CFrmsInfoView::OnLButtonDown(UINT nFlags, CPoint point)
+{
+	if (!mGraphRect.PtInRect(point)) {
+		CView::OnLButtonDown(nFlags, point);
+		return;
+	}
+
+	CComparerDoc *pDoc = GetDocument();
+	if (pDoc->mMinFrames <= 0) {
+		CView::OnLButtonDown(nFlags, point);
+		return;
+	}
+
+	int graphX = point.x - mGraphRect.left - GRAPH_IN_MARGIN_L;
+	long frameID = mPsnrCal->FrameAtX(graphX);
+	if (frameID < 0) {
+		CView::OnLButtonDown(nFlags, point);
+		return;
+	}
+
+	pDoc->KillPlayTimer();
+	pDoc->SetScenes(frameID);
+
+	// Refresh the per-frame metric label shown in FrmInfoView for the new
+	// pair of frames.
+	IFrmCmpStrategy *compareStrategy = pDoc->mFrmCmpStrategy;
+	if (compareStrategy) {
+		CMainFrame *pMainFrm = static_cast<CMainFrame *>(AfxGetMainWnd());
+		ComparerPane *paneL = &pDoc->mPane[CComparerDoc::IMG_VIEW_1];
+		ComparerPane *paneR = &pDoc->mPane[CComparerDoc::IMG_VIEW_2];
+		compareStrategy->CalMetrics(paneL, paneR,
+			pMainFrm->mMetricIdx, pDoc->mFrmState);
+	}
+
+	pDoc->UpdateAllViews(NULL);
+
+	CView::OnLButtonDown(nFlags, point);
 }

--- a/Comparer/FrmsInfoView.h
+++ b/Comparer/FrmsInfoView.h
@@ -69,6 +69,7 @@ public:
 	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 	afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
 	afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
+	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 };
 
 

--- a/Comparer/MetricCal.cpp
+++ b/Comparer/MetricCal.cpp
@@ -193,6 +193,29 @@ void MetricCal::ZoomAtX(short zDelta, int graphX)
 		mViewEndFrame = mViewStartFrame + 1;
 }
 
+long MetricCal::FrameAtX(int graphX) const
+{
+	if (mStepCount == 0 || mFrameIdx == 0)
+		return -1;
+	int graphW = getGraphW();
+	if (graphW <= 0)
+		return -1;
+
+	if (graphX < 0)       graphX = 0;
+	if (graphX > graphW)  graphX = graphW;
+
+	size_t viewSpan = mViewEndFrame > mViewStartFrame
+		? mViewEndFrame - mViewStartFrame : 1;
+	long frameID = long(mViewStartFrame)
+		+ long((size_t(graphX) * viewSpan) / size_t(graphW));
+
+	// Clamp to frames that actually have parsed metrics so far.
+	long maxFrame = long(mFrameIdx) - 1;
+	if (frameID > maxFrame) frameID = maxFrame;
+	if (frameID < 0)        frameID = 0;
+	return frameID;
+}
+
 void MetricCal::CalMinMaxAccum()
 {
 	size_t i;

--- a/Comparer/MetricCal.h
+++ b/Comparer/MetricCal.h
@@ -66,6 +66,9 @@ public:
 	void ZoomAtX(short zDelta, int graphX);
 	// Restore the X axis to cover the full parsed range.
 	void ResetView();
+	// Frame index at the given graph-area X pixel under the current view
+	// range. Returns -1 if no data is available.
+	long FrameAtX(int graphX) const;
 
 	void DrawCmpResult(CDC* pDC, CFont *font) const;
 	void DrawYLabel(CDC* pDC, CRect *yLabelRect, CFont *font) const;

--- a/Comparer/PosInfoView.cpp
+++ b/Comparer/PosInfoView.cpp
@@ -84,8 +84,14 @@ void CPosInfoView::DrawEachRect(CDC* pDC,
 {
 	CComparerDoc* pDoc = GetDocument();
 
+	bool isCurFrame = pane->isAvail() && (i == pane->curFrameID);
+	bool isLeftPane = (pane == &pDoc->mPane[CComparerDoc::IMG_VIEW_1]);
+
 	COLORREF frameColor;
-	if (!pane->isAvail()) {
+	if (isCurFrame) {
+		// Pane-specific highlight so left vs right is obvious at a glance.
+		frameColor = isLeftPane ? Q1UI_COLOR_ACCENT : Q1UI_COLOR_WARNING;
+	} else if (!pane->isAvail()) {
 		frameColor = Q1UI_COLOR_SURFACE;
 	} else if (parseDone) {
 		frameColor = Q1UI_COLOR_ACCENT_SOFT;
@@ -112,12 +118,12 @@ void CPosInfoView::DrawEachRect(CDC* pDC,
 		pDC->SelectObject(prev);
 	}
 
-	const COLORREF curIdColor = Q1UI_COLOR_ACCENT;
-	COLORREF preColor;
-	bool isCurFrame = i == pane->curFrameID;
-
-	if (isCurFrame)
-		preColor = pDC->SetTextColor(curIdColor);
+	COLORREF preColor = 0;
+	if (isCurFrame) {
+		// Use surface (near-white) on the saturated highlight fill for
+		// maximum contrast.
+		preColor = pDC->SetTextColor(Q1UI_COLOR_SURFACE);
+	}
 
 	CString numStr;
 	numStr.Format(_T("%d"), i);


### PR DESCRIPTION
Previously only the frame-number text in the timeline was tinted with the accent color, and both panes used the same color — easy to miss, impossible to tell apart at a glance.

This change fills the entire row of the current frame with a pane-specific color (blue for the left pane, orange for the right) and draws the number in surface white for contrast. Both panes are now immediately distinguishable and the current frame jumps out of the long timeline.

## Try it
- Open a long video pair.
- Step through frames or click the metric graph.
- The current frame row in the left timeline panel is filled with the pane's accent color, distinct between left and right.