### PR TITLE
Move thumbnail browser to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Q1View are documented here. Releases follow [semantic ver
 ## [Unreleased]
 
 ### Changed
-- Viewer: the thumbnail browser now opens on the left in both the MFC and Qt front ends, while the fixed outer window, drawer width, manual zoom scale, image-space focal point, fit behavior, synchronized view state, and video playback remain stable across drawer toggles and divider resizing. (issue #96)
+- Viewer: the thumbnail browser now opens on the left in both the MFC and Qt front ends, while the fixed outer window, drawer width, manual zoom scale, image-space focal point, fit behavior, synchronized view state, and video playback remain stable across drawer toggles and divider resizing; during active MFC video playback the drawer switches directly to its final layout instead of running a splitter animation that can starve 60 fps presentation. (issue #96)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Q1View are documented here. Releases follow [semantic ver
 ## [Unreleased]
 
 ### Changed
-- Viewer: the thumbnail browser now opens on the left in both the MFC and Qt front ends, while the fixed outer window, drawer width, manual zoom scale, image-space focal point, fit behavior, synchronized view state, and video playback remain stable across drawer toggles and divider resizing; during active MFC video playback the drawer switches directly to its final layout instead of running a splitter animation that can starve 60 fps presentation, and compensates the moved viewport so the video subject does not jump sideways on screen. (issue #96)
+- Viewer: the thumbnail browser now opens on the left in both the MFC and Qt front ends, while the fixed outer window, drawer width, manual zoom scale, image-space focal point, fit behavior, synchronized view state, and video playback remain stable across drawer toggles and divider resizing; during active MFC video playback the drawer switches directly to its final layout instead of running a splitter animation that can starve 60 fps presentation, preserves the subject's desktop position, clears newly exposed canvas edges, and holds the last composed frame above the separate MFC and DXGI surfaces until the final layout is ready so no striped or partial transition frame reaches the display. (issue #96)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Q1View are documented here. Releases follow [semantic ver
 
 ## [Unreleased]
 
+### Changed
+- Viewer: the thumbnail browser now opens on the left in both the MFC and Qt front ends, while the fixed outer window, drawer width, manual zoom scale, image-space focal point, fit behavior, synchronized view state, and video playback remain stable across drawer toggles and divider resizing. (issue #96)
+
 ---
 
 ## [2.7.11] — 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to Q1View are documented here. Releases follow [semantic ver
 ## [Unreleased]
 
 ### Changed
-- Viewer: the thumbnail browser now opens on the left in both the MFC and Qt front ends, while the fixed outer window, drawer width, manual zoom scale, image-space focal point, fit behavior, synchronized view state, and video playback remain stable across drawer toggles and divider resizing; during active MFC video playback the drawer switches directly to its final layout instead of running a splitter animation that can starve 60 fps presentation. (issue #96)
+- Viewer: the thumbnail browser now opens on the left in both the MFC and Qt front ends, while the fixed outer window, drawer width, manual zoom scale, image-space focal point, fit behavior, synchronized view state, and video playback remain stable across drawer toggles and divider resizing; during active MFC video playback the drawer switches directly to its final layout instead of running a splitter animation that can starve 60 fps presentation, and compensates the moved viewport so the video subject does not jump sideways on screen. (issue #96)
 
 ---
 

--- a/Viewer/MainFrm.cpp
+++ b/Viewer/MainFrm.cpp
@@ -847,9 +847,30 @@ void CMainFrame::SetDrawerVisibleImmediately(bool visible)
 	if (visible == mDrawerVisible)
 		return;
 
+	CViewerView *pView = DYNAMIC_DOWNCAST(CViewerView, GetActiveView());
+	CRect oldViewRect;
+	const bool preserveScreenPosition = pView != NULL && !pView->IsFitToWindow() &&
+		pView->GetSafeHwnd() != NULL;
+	CPoint oldImageOrigin;
+	if (preserveScreenPosition) {
+		pView->GetWindowRect(&oldViewRect);
+		oldImageOrigin.SetPoint(oldViewRect.left + pView->mXDst,
+			oldViewRect.top + pView->mYDst);
+	}
+
 	mDrawerVisible = visible;
 	PinDrawerColumn();
-	SettleViewAfterDrawerResize(true);
+
+	if (preserveScreenPosition) {
+		// OnSize has preserved zoom and the image-space viewport anchor. For active
+		// video, compensate the viewport's desktop movement as well so the subject
+		// does not jump sideways when the left drawer appears or disappears.
+		pView->RestoreImageScreenOrigin(oldImageOrigin);
+		pView->RedrawWindow(NULL, NULL,
+			RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
+	} else {
+		SettleViewAfterDrawerResize(true);
+	}
 
 	// Populate only after the final column exists. Thumbnail decoding remains on
 	// its background workers, and no intermediate splitter sizes compete with

--- a/Viewer/MainFrm.cpp
+++ b/Viewer/MainFrm.cpp
@@ -124,8 +124,8 @@ BEGIN_MESSAGE_MAP(CDrawerSplitter, CSplitterWnd)
 	ON_WM_CANCELMODE()
 END_MESSAGE_MAP()
 
-// The divider bar is the gap between the image view (column 0) and the drawer
-// (column 1): client x in [col0 width, col0 width + bar], full height.
+// The divider bar follows the left drawer (column 0): client x in
+// [drawer width, drawer width + bar], full height.
 bool CDrawerSplitter::OnBar(CPoint point) const
 {
 	int bar = BarWidth();
@@ -157,23 +157,20 @@ void CDrawerSplitter::OnMouseMove(UINT nFlags, CPoint point)
 		CRect rc;
 		GetClientRect(&rc);
 		int bar = BarWidth();
-		// col0 is the image view's width; its bounds keep the drawer within
-		// [DRAWER_MIN_W, DRAWER_MAX_W] and the image view at >= DRAWER_MIN_IMAGE.
-		// Without the max-drawer bound a wide (maximized) window let the divider run
-		// far left and then snap back to the max on release (issue #85).
-		int lo = rc.Width() - bar - DRAWER_MAX_W;     // drawer's maximum width
-		if (lo < DRAWER_MIN_IMAGE)
-			lo = DRAWER_MIN_IMAGE;                    // image view's minimum width
-		int hi = rc.Width() - bar - DRAWER_MIN_W;     // drawer's minimum width
-		if (hi < lo)
-			hi = lo;
+		// col0 is now the drawer itself. Clamp its right edge to the shared
+		// drawer bounds while keeping the image view at DRAWER_MIN_IMAGE (issue #85).
+		int hi = rc.Width() - bar - DRAWER_MIN_IMAGE;
+		if (hi > DRAWER_MAX_W)
+			hi = DRAWER_MAX_W;
+		if (hi < DRAWER_MIN_W)
+			hi = DRAWER_MIN_W;
 		int col0 = point.x;
-		if (col0 < lo) col0 = lo;
+		if (col0 < DRAWER_MIN_W) col0 = DRAWER_MIN_W;
 		else if (col0 > hi) col0 = hi;
 		int col1 = rc.Width() - bar - col0;
 		if (col1 < 0) col1 = 0;
-		SetColumnInfo(0, col0, DRAWER_MIN_IMAGE);
-		SetColumnInfo(1, col1, DRAWER_MIN_W);
+		SetColumnInfo(0, col0, DRAWER_MIN_W);
+		SetColumnInfo(1, col1, DRAWER_MIN_IMAGE);
 		RecalcLayout();
 		if (mFrame != NULL)
 			mFrame->OnDrawerDividerTracking();
@@ -747,23 +744,22 @@ BOOL CMainFrame::OnCreateClient(LPCREATESTRUCT lpcs, CCreateContext* pContext)
 	mwndSplitter.mFrame = this;
 	mwndSplitter.SetBarVisible(mDrawerVisible);
 
-	// Image view in column 0 (left) and the thumbnail drawer in column 1
-	// (right). The frame stays a fixed size; opening the drawer or dragging the
-	// divider shrinks/grows the image-view column instead (issue #76).
-	if (!mwndSplitter.CreateView(0, 0, pContext->m_pNewViewClass,
+	// Drawer in column 0 (left), image view in column 1 (right). The outer frame
+	// remains fixed; opening or dragging the drawer only changes these columns.
+	mpDrawer = new CThumbnailPane();
+	if (!mpDrawer->CreatePane(&mwndSplitter, mwndSplitter.IdFromRowCol(0, 0)))
+		return FALSE;
+
+	if (!mwndSplitter.CreateView(0, 1, pContext->m_pNewViewClass,
 			CSize(200, 200), pContext))
 		return FALSE;
 
-	mpDrawer = new CThumbnailPane();
-	if (!mpDrawer->CreatePane(&mwndSplitter, mwndSplitter.IdFromRowCol(0, 1)))
-		return FALSE;
-
-	mwndSplitter.SetColumnInfo(0, 200, DRAWER_MIN_IMAGE);
-	mwndSplitter.SetColumnInfo(1, mDrawerVisible ? mDrawerWidth : 0, DRAWER_MIN_W);
+	mwndSplitter.SetColumnInfo(0, mDrawerVisible ? mDrawerWidth : 0, DRAWER_MIN_W);
+	mwndSplitter.SetColumnInfo(1, 200, DRAWER_MIN_IMAGE);
 	mwndSplitter.RecalcLayout();
 
 	// The image view must remain the active view for doc/view command routing.
-	SetActiveView(static_cast<CView *>(mwndSplitter.GetPane(0, 0)));
+	SetActiveView(static_cast<CView *>(mwndSplitter.GetPane(0, 1)));
 	mSplitterReady = true;
 
 	// Full-window help overlay sits above the splitter (created last, raised to
@@ -798,8 +794,8 @@ void CMainFrame::PinDrawerColumn()
 	if (viewCol < 0)
 		viewCol = 0;
 
-	mwndSplitter.SetColumnInfo(0, viewCol, DRAWER_MIN_IMAGE);  // image view (left)
-	mwndSplitter.SetColumnInfo(1, drawerCol, DRAWER_MIN_W);    // drawer (right)
+	mwndSplitter.SetColumnInfo(0, drawerCol, DRAWER_MIN_W);    // drawer (left)
+	mwndSplitter.SetColumnInfo(1, viewCol, DRAWER_MIN_IMAGE);  // image view (right)
 	mwndSplitter.RecalcLayout();
 }
 
@@ -889,12 +885,9 @@ void CMainFrame::ApplyDrawerColumn(int drawerCol)
 	if (viewCol < 0)
 		viewCol = 0;
 
-	mwndSplitter.SetColumnInfo(0, viewCol, DRAWER_MIN_IMAGE);  // image view, shrinks
-	mwndSplitter.SetColumnInfo(1, drawerCol, 0);               // drawer, grows
+	mwndSplitter.SetColumnInfo(0, drawerCol, 0);               // drawer, grows left
+	mwndSplitter.SetColumnInfo(1, viewCol, DRAWER_MIN_IMAGE);  // image view, shrinks
 	mwndSplitter.RecalcLayout();
-
-	// The view column changed size, so refit the image into it as it slides.
-	RefitView();
 }
 
 void CMainFrame::OnTimer(UINT_PTR nIDEvent)
@@ -928,9 +921,9 @@ void CMainFrame::FinalizeDrawerAnimation()
 	if (!mDrawerAnimOpening)
 		mDrawerVisible = false;
 
-	// Snap to the exact final column/layout for the resting state, then refit.
+	// Snap to the exact resting layout, then perform at most one final fit.
 	PinDrawerColumn();
-	RefitView();
+	SettleViewAfterDrawerResize();
 
 	// Release the slide lock and settle the grid into its now-final width.
 	if (mpDrawer && ::IsWindow(mpDrawer->GetSafeHwnd()))
@@ -975,10 +968,11 @@ void CMainFrame::OnDrawerDividerTracking()
 	if (!mSplitterReady || mDrawerAnimating)
 		return;
 
-	// The splitter has already resized the child panes. Refit and repaint the image
-	// view in the same mouse-move pass, otherwise the newly exposed area can briefly
-	// show stale pixels while Windows waits for the next paint message.
-	RefitView(true);
+	// CViewerView::OnSize preserves the current scale and image-space focal point.
+	// Repaint that stable transform, but defer a fit calculation until mouse-up.
+	CViewerView *pView = DYNAMIC_DOWNCAST(CViewerView, GetActiveView());
+	if (pView != NULL)
+		pView->RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
 
 	if (mpDrawer != NULL && ::IsWindow(mpDrawer->GetSafeHwnd())) {
 		mpDrawer->RedrawWindow(NULL, NULL,
@@ -994,7 +988,7 @@ void CMainFrame::OnDrawerDividerDragged()
 		// Adopt the width the user dragged the drawer column to, clamped to the
 		// shared bounds, then re-pin (enforces the minimum image view) and refit.
 		int cur = 0, mn = 0;
-		mwndSplitter.GetColumnInfo(1, cur, mn);
+		mwndSplitter.GetColumnInfo(0, cur, mn);
 		if (cur < DRAWER_MIN_W) cur = DRAWER_MIN_W;
 		if (cur > DRAWER_MAX_W) cur = DRAWER_MAX_W;
 		mDrawerWidth = cur;
@@ -1006,7 +1000,7 @@ void CMainFrame::OnDrawerDividerDragged()
 	mDrawerResizing = false;
 	if (commit) {
 		PinDrawerColumn();
-		RefitView();
+		SettleViewAfterDrawerResize();
 	}
 
 	// Resume and re-fit the grid once at the final width.
@@ -1014,11 +1008,12 @@ void CMainFrame::OnDrawerDividerDragged()
 		mpDrawer->SetResizing(false);
 }
 
-void CMainFrame::RefitView(bool updateNow)
+void CMainFrame::SettleViewAfterDrawerResize(bool updateNow)
 {
 	CViewerView *pView = DYNAMIC_DOWNCAST(CViewerView, GetActiveView());
 	if (pView != NULL) {
-		pView->FitToWindow();
+		if (pView->IsFitToWindow())
+			pView->FitToWindow();
 		if (updateNow) {
 			pView->RedrawWindow(NULL, NULL, RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
 		} else {

--- a/Viewer/MainFrm.cpp
+++ b/Viewer/MainFrm.cpp
@@ -31,6 +31,9 @@
 #include "Shlwapi.h"
 
 #include <algorithm>
+#include <dwmapi.h>
+
+#pragma comment(lib, "dwmapi.lib")
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -423,6 +426,79 @@ BOOL CHelpOverlay::OnEraseBkgnd(CDC * /*pDC*/)
 }
 
 
+BOOL CDrawerTransitionOverlay::CreateOverlay(CWnd *pParent)
+{
+	mOwner = pParent;
+	LPCTSTR cls = AfxRegisterWndClass(0, ::LoadCursor(NULL, IDC_ARROW), NULL, NULL);
+	return CreateEx(WS_EX_LAYERED | WS_EX_TOOLWINDOW | WS_EX_NOACTIVATE |
+		WS_EX_TRANSPARENT, cls, _T(""), WS_POPUP, CRect(0, 0, 0, 0), pParent, 0);
+}
+
+bool CDrawerTransitionOverlay::ShowSnapshot()
+{
+	if (!GetSafeHwnd() || !mOwner || !::IsWindow(mOwner->GetSafeHwnd()))
+		return false;
+
+	CRect rc;
+	mOwner->GetClientRect(&rc);
+	mOwner->ClientToScreen(&rc);
+	const int width = rc.Width();
+	const int height = rc.Height();
+	if (width <= 0 || height <= 0)
+		return false;
+
+	BITMAPINFO bmi = {};
+	bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+	bmi.bmiHeader.biWidth = width;
+	bmi.bmiHeader.biHeight = -height;
+	bmi.bmiHeader.biPlanes = 1;
+	bmi.bmiHeader.biBitCount = 32;
+	bmi.bmiHeader.biCompression = BI_RGB;
+
+	void *bits = NULL;
+	HDC screen = ::GetDC(NULL);
+	HBITMAP dib = ::CreateDIBSection(screen, &bmi, DIB_RGB_COLORS, &bits, NULL, 0);
+	HDC mem = dib ? ::CreateCompatibleDC(screen) : NULL;
+	if (!dib || !mem) {
+		if (mem) ::DeleteDC(mem);
+		if (dib) ::DeleteObject(dib);
+		::ReleaseDC(NULL, screen);
+		return false;
+	}
+
+	HBITMAP oldBitmap = static_cast<HBITMAP>(::SelectObject(mem, dib));
+	::BitBlt(mem, 0, 0, width, height, screen, rc.left, rc.top,
+		SRCCOPY | CAPTUREBLT);
+	BYTE *pixels = static_cast<BYTE *>(bits);
+	for (size_t i = 0, count = static_cast<size_t>(width) * height; i < count; ++i)
+		pixels[i * 4 + 3] = 255;
+
+	POINT destination = { rc.left, rc.top };
+	SIZE size = { width, height };
+	POINT source = { 0, 0 };
+	BLENDFUNCTION blend = { AC_SRC_OVER, 0, 255, AC_SRC_ALPHA };
+	BOOL updated = ::UpdateLayeredWindow(m_hWnd, screen, &destination, &size,
+		mem, &source, 0, &blend, ULW_ALPHA);
+
+	::SelectObject(mem, oldBitmap);
+	::DeleteDC(mem);
+	::DeleteObject(dib);
+	::ReleaseDC(NULL, screen);
+	if (!updated)
+		return false;
+
+	ShowWindow(SW_SHOWNA);
+	::DwmFlush();
+	return true;
+}
+
+void CDrawerTransitionOverlay::Hide()
+{
+	if (GetSafeHwnd() && (GetStyle() & WS_VISIBLE) != 0)
+		ShowWindow(SW_HIDE);
+}
+
+
 CMainFrame::CMainFrame()
 : mSyncInput(false)
 , mSyncViewStatePending(false)
@@ -765,6 +841,7 @@ BOOL CMainFrame::OnCreateClient(LPCREATESTRUCT lpcs, CCreateContext* pContext)
 	// Full-window help overlay sits above the splitter (created last, raised to
 	// top when shown). Failure is non-fatal -- the app simply has no help panel.
 	mHelpOverlay.CreateOverlay(this);
+	mDrawerTransitionOverlay.CreateOverlay(this);
 	return TRUE;
 }
 
@@ -858,6 +935,10 @@ void CMainFrame::SetDrawerVisibleImmediately(bool visible)
 			oldViewRect.top + pView->mYDst);
 	}
 
+	// The drawer and DXGI view are separate child surfaces, so a desktop capture
+	// holds the last fully composed frame above them while both settle underneath.
+	const bool snapshotShown = mDrawerTransitionOverlay.ShowSnapshot();
+
 	mDrawerVisible = visible;
 	PinDrawerColumn();
 
@@ -866,15 +947,25 @@ void CMainFrame::SetDrawerVisibleImmediately(bool visible)
 		// video, compensate the viewport's desktop movement as well so the subject
 		// does not jump sideways when the left drawer appears or disappears.
 		pView->RestoreImageScreenOrigin(oldImageOrigin);
-		pView->RedrawWindow(NULL, NULL,
-			RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
 	} else {
 		SettleViewAfterDrawerResize(true);
 	}
 
-	// Populate only after the final column exists. Thumbnail decoding remains on
-	// its background workers, and no intermediate splitter sizes compete with
-	// video presentation on the UI thread.
+	if (pView != NULL) {
+		pView->RedrawWindow(NULL, NULL,
+			RDW_INVALIDATE | RDW_UPDATENOW | RDW_NOERASE);
+	}
+
+	mwndSplitter.RedrawWindow(NULL, NULL,
+		RDW_INVALIDATE | RDW_UPDATENOW | RDW_ALLCHILDREN | RDW_NOERASE);
+	if (snapshotShown) {
+		::DwmFlush();
+		mDrawerTransitionOverlay.Hide();
+	}
+
+	// Start the drawer's list/background thumbnail work only after the stable
+	// video surface is visible again, so folder setup cannot extend the frozen
+	// transition snapshot.
 	if (visible && mpDrawer != NULL && ::IsWindow(mpDrawer->GetSafeHwnd())) {
 		CDocument *pDoc = GetActiveDocument();
 		if (pDoc != NULL && !pDoc->GetPathName().IsEmpty())

--- a/Viewer/MainFrm.cpp
+++ b/Viewer/MainFrm.cpp
@@ -826,9 +826,39 @@ void CMainFrame::OnToggleDrawer()
 	if (!mSplitterReady || mDrawerAnimating)
 		return;
 
+	// A 60 fps video already consumes the UI thread once per presented frame.
+	// Animating the splitter adds twelve RecalcLayout/ResizeBuffers passes on that
+	// same thread, so timer ticks can be delayed for nearly a second and leave the
+	// drawer apparently stuck between widths. During playback, apply the resting
+	// layout atomically; the decoder and playback clock remain untouched.
+	CViewerView *pView = DYNAMIC_DOWNCAST(CViewerView, GetActiveView());
+	if (pView != NULL && pView->mIsPlaying) {
+		SetDrawerVisibleImmediately(!mDrawerVisible);
+		return;
+	}
+
 	// mDrawerWidth is the fixed target width; it is never rederived from the
 	// laid-out column, so repeated toggles can't accumulate any drift.
 	StartDrawerAnimation(!mDrawerVisible);
+}
+
+void CMainFrame::SetDrawerVisibleImmediately(bool visible)
+{
+	if (visible == mDrawerVisible)
+		return;
+
+	mDrawerVisible = visible;
+	PinDrawerColumn();
+	SettleViewAfterDrawerResize(true);
+
+	// Populate only after the final column exists. Thumbnail decoding remains on
+	// its background workers, and no intermediate splitter sizes compete with
+	// video presentation on the UI thread.
+	if (visible && mpDrawer != NULL && ::IsWindow(mpDrawer->GetSafeHwnd())) {
+		CDocument *pDoc = GetActiveDocument();
+		if (pDoc != NULL && !pDoc->GetPathName().IsEmpty())
+			mpDrawer->SetCurrentFile(pDoc->GetPathName());
+	}
 }
 
 void CMainFrame::StartDrawerAnimation(bool opening)

--- a/Viewer/MainFrm.h
+++ b/Viewer/MainFrm.h
@@ -54,7 +54,7 @@ class CMainFrame;
 // thumbnail drawer.
 #define DRAWER_SPLIT_BAR  6
 
-// Static splitter hosting the image view (column 0) and the thumbnail drawer
+// Static splitter hosting the thumbnail drawer (column 0) and image view
 // (column 1). The divider is a thin, draggable bar so the user can resize the
 // drawer (e.g. to read long file names); dragging redistributes width between
 // the two panes inside the fixed window, never resizing the frame (issue #76).
@@ -237,8 +237,9 @@ private:
 	void StartDrawerAnimation(bool opening);
 	void ApplyDrawerColumn(int drawerCol);
 	void FinalizeDrawerAnimation();
-	// Refit the image into the current view column (after a drawer resize).
-	void RefitView(bool updateNow = false);
+	// Settle the image after a drawer resize. Active fit mode is recomputed once
+	// at the final width; manual mode only repaints its preserved transform.
+	void SettleViewAfterDrawerResize(bool updateNow = false);
 	afx_msg LRESULT Reload(WPARAM wParam, LPARAM lParam);
 	afx_msg BOOL OnCopyData(CWnd *pWnd, COPYDATASTRUCT *pCopyDataStruct);
 	afx_msg LRESULT OnApplySyncInput(WPARAM wParam, LPARAM lParam);

--- a/Viewer/MainFrm.h
+++ b/Viewer/MainFrm.h
@@ -122,6 +122,19 @@ private:
 	CWnd *mOwner = NULL;      // the frame whose client this overlay covers
 };
 
+// Holds the last fully composed client image above the separate MFC and DXGI
+// child surfaces while an active-video drawer toggle settles underneath it.
+class CDrawerTransitionOverlay : public CWnd
+{
+public:
+	BOOL CreateOverlay(CWnd *pParent);
+	bool ShowSnapshot();
+	void Hide();
+
+private:
+	CWnd *mOwner = NULL;
+};
+
 class CMainFrame : public CFrameWnd
 {
 protected: // create from serialization only
@@ -158,6 +171,7 @@ private:
 
 	// Full-window shortcut/help overlay (issue #79).
 	CHelpOverlay mHelpOverlay;
+	CDrawerTransitionOverlay mDrawerTransitionOverlay;
 
 // Operations
 public:

--- a/Viewer/MainFrm.h
+++ b/Viewer/MainFrm.h
@@ -234,6 +234,7 @@ private:
 	BOOL ResolveComparatorPath(CString &cmperPath);
 	BOOL LaunchComparator(const CString &cmperPath, const CString &quotedArgs);
 	void PinDrawerColumn();
+	void SetDrawerVisibleImmediately(bool visible);
 	void StartDrawerAnimation(bool opening);
 	void ApplyDrawerColumn(int drawerCol);
 	void FinalizeDrawerAnimation();

--- a/Viewer/ViewerView.cpp
+++ b/Viewer/ViewerView.cpp
@@ -709,7 +709,14 @@ void CViewerView::_ScaleRgb(BYTE *src, BYTE *dst, int sDst, q1::GridInfo &gi)
 {
 	long gap, yStart, yEnd, xStart, xEnd;
 
-	if (mYDst > 0 || mXDst > 0) // The image is smaller than the canvas.
+	// Clear whenever any canvas edge is outside the image. Normally letterboxing
+	// exposes the left/top edges too, but preserving the video's desktop origin
+	// across a left-drawer toggle can crop the left edge while exposing only the
+	// right edge. Leaving that strip untouched reuses prior RGB rows and flickers
+	// conspicuously as striped video noise during playback.
+	const bool hasExposedCanvas = mXDst > 0 || mYDst > 0 ||
+		mXDst + mWDst < mWCanvas || mYDst + mHDst < mHCanvas;
+	if (hasExposedCanvas)
 		memset(dst, 0xf7, sDst * mHClient * QIMG_DST_RGB_BYTES);
 
 	// Visible range of the scaled image on the canvas.

--- a/Viewer/ViewerView.cpp
+++ b/Viewer/ViewerView.cpp
@@ -469,6 +469,24 @@ void CViewerView::FitToWindow()
 	pMainFrm->UpdateMagnication(mN, mWDst, mHDst);
 }
 
+void CViewerView::RestoreImageScreenOrigin(const CPoint &screenOrigin)
+{
+	if (mN <= 0.0f || GetSafeHwnd() == NULL)
+		return;
+
+	CRect viewRect;
+	GetWindowRect(&viewRect);
+	mXDst = screenOrigin.x - viewRect.left;
+	mYDst = screenOrigin.y - viewRect.top;
+
+	// Reconstruct the centre-relative offsets without DeterminDestPos's usual
+	// edge clamp. A temporary letterbox strip is preferable here: clamping would
+	// move the video subject by up to half the drawer width and cause eye fatigue.
+	mXOff = (mXDst - (mWCanvas - mWDst) / 2.0f) / mN;
+	mYOff = (mYDst - (mHCanvas - mHDst) / 2.0f) / mN;
+	Invalidate(FALSE);
+}
+
 void CViewerView::Initialize(int nFrame, size_t rgbStride, int w, int h, bool preserveViewState)
 {
 	float prevD = mD;
@@ -705,15 +723,19 @@ void CViewerView::_ScaleRgb(BYTE *src, BYTE *dst, int sDst, q1::GridInfo &gi)
 	}
 
 	if (mXDst >= 0 && sDst >= mWDst) {
-		gap = (sDst - mWDst) * QIMG_DST_RGB_BYTES;
 		dst += mXDst * QIMG_DST_RGB_BYTES;
 		xStart = 0;
-		xEnd = mWDst;
+		xEnd = QMIN(mWDst, mWCanvas - mXDst);
 	} else {
-		gap = (sDst - mWClient) * QIMG_DST_RGB_BYTES;
 		xStart = -mXDst;
 		xEnd = QMIN(mWDst, mWCanvas - mXDst);
 	}
+	// Use the actual visible span, not the canvas width. Playback drawer layout
+	// preservation can intentionally leave a letterbox strip on one side so the
+	// video subject stays fixed in desktop coordinates; assuming a full-width
+	// span here would advance each output row by the wrong stride and corrupt it.
+	const long visibleWidth = QMAX(0, xEnd - xStart);
+	gap = (sDst - visibleWidth) * QIMG_DST_RGB_BYTES;
 
 	if (mInterpol) {
 		q1::Interpolate(src, mH, mW, mWCanvas, xStart, xEnd, yStart, yEnd, mNnOffsetBuf, dst);

--- a/Viewer/ViewerView.cpp
+++ b/Viewer/ViewerView.cpp
@@ -169,6 +169,7 @@ CViewerView::CViewerView()
 , mH(VIEWER_DEF_H)
 , mD(0.f)
 , mN(ZOOM_RATIO(mD))
+, mFitToWindow(true)
 , mIsClicked(false)
 , mXOff(.0f)
 , mYOff(.0f)
@@ -439,6 +440,7 @@ void CViewerView::AdjustWindowSize()
 
 void CViewerView::FitToWindow()
 {
+	mFitToWindow = true;
 	CRect rcClient;
 	GetClientRect(&rcClient);
 	mWClient = rcClient.Width();
@@ -473,6 +475,7 @@ void CViewerView::Initialize(int nFrame, size_t rgbStride, int w, int h, bool pr
 	float prevN = mN;
 	float prevXOff = mXOff;
 	float prevYOff = mYOff;
+	bool prevFitToWindow = mFitToWindow;
 
 	mW = w;
 	mH = h;
@@ -480,6 +483,7 @@ void CViewerView::Initialize(int nFrame, size_t rgbStride, int w, int h, bool pr
 	mN = ZOOM_RATIO(mD);
 	mXOff = 0.0f;
 	mYOff = 0.0f;
+	mFitToWindow = true;
 
 	if (nFrame > 1)
 		mHProgress = PROGRESS_BAR_H;
@@ -493,6 +497,7 @@ void CViewerView::Initialize(int nFrame, size_t rgbStride, int w, int h, bool pr
 		mN = prevN;
 		mXOff = prevXOff;
 		mYOff = prevYOff;
+		mFitToWindow = prevFitToWindow;
 		SetDstSize();
 	}
 
@@ -1490,6 +1495,7 @@ void CViewerView::ChangeZoom(short zDelta, CPoint &pt)
 {
 	if (mN > ZOOM_MAX && zDelta > 0)
 		return;
+	mFitToWindow = false;
 
 	CPoint clientPoint = pt;
 
@@ -1533,6 +1539,7 @@ void CViewerView::ApplyViewState(float zoom, float xOff, float yOff)
 	int previousWidth = mWDst;
 	int previousHeight = mHDst;
 
+	mFitToWindow = false;
 	mN = zoom;
 	mD = ZOOM_DELTA(mN);
 	mXOff = xOff;
@@ -1829,6 +1836,7 @@ void CViewerView::OnMouseMove(UINT nFlags, CPoint point)
 		}
 	} else { // if not the SelMode
 		if (mIsClicked) {
+			mFitToWindow = false;
 			mXOff = mXInitOff + (point.x - mPointS.x) / mN;
 			mYOff = mYInitOff + (point.y - mPointS.y) / mN;
 

--- a/Viewer/ViewerView.h
+++ b/Viewer/ViewerView.h
@@ -103,6 +103,9 @@ public:
 
 	// Zoom & Move
 	float mD, mN;
+	// True while viewport changes should recompute the best-fit transform. Manual
+	// zoom/pan and synchronized view states deliberately leave this mode.
+	bool mFitToWindow;
 	QPoint mPointS, mPointE;
 	bool mIsClicked;
 	float mXOff, mYOff;
@@ -186,6 +189,7 @@ public:
 public:
 	void AdjustWindowSize();
 	void FitToWindow();
+	bool IsFitToWindow() const { return mFitToWindow; }
 	void ProgressiveDraw(CDC *pDC, CViewerDoc* pDoc, int frameID);
 	void UpdateVolumeFromPoint(CPoint point);
 	void DrawMuteButton(CDC *pDC, const CRect &rect);

--- a/Viewer/ViewerView.h
+++ b/Viewer/ViewerView.h
@@ -190,6 +190,9 @@ public:
 	void AdjustWindowSize();
 	void FitToWindow();
 	bool IsFitToWindow() const { return mFitToWindow; }
+	// Keep the displayed image origin fixed in desktop coordinates when the
+	// hosting viewport moves during an in-playback drawer layout change.
+	void RestoreImageScreenOrigin(const CPoint &screenOrigin);
 	void ProgressiveDraw(CDC *pDC, CViewerDoc* pDoc, int frameID);
 	void UpdateVolumeFromPoint(CPoint point);
 	void DrawMuteButton(CDC *pDC, const CRect &rect);

--- a/ViewerQt/MainWindow.cpp
+++ b/ViewerQt/MainWindow.cpp
@@ -88,6 +88,7 @@ MainWindow::MainWindow(QWidget *parent)
 	: QMainWindow(parent),
 	  mImageView(new ImageView),
 	  mScrollArea(new QScrollArea),
+	  mViewportSettleTimer(new QTimer(this)),
 	  mCentralStack(new QStackedWidget),
 	  mVideoView(nullptr),
 	  mShowingVideo(false),
@@ -173,6 +174,10 @@ MainWindow::MainWindow(QWidget *parent)
 	mScrollArea->viewport()->setFocusPolicy(Qt::StrongFocus);
 	mScrollArea->viewport()->grabGesture(Qt::PinchGesture);
 	mScrollArea->viewport()->installEventFilter(this);
+	mViewportSettleTimer->setSingleShot(true);
+	mViewportSettleTimer->setInterval(40);
+	connect(mViewportSettleTimer, &QTimer::timeout,
+		this, &MainWindow::settleViewportAfterResize);
 	// Image page = scroll area on top of the raw/sequence seek bar. The seek bar
 	// is a frame slider plus a "frame / max  cur / dur" readout; it stays hidden
 	// unless a multi-frame raw source is open (see updateSeekBar). Clicking the
@@ -230,12 +235,12 @@ MainWindow::MainWindow(QWidget *parent)
 	mThumbDock = new QDockWidget(tr("Thumbnail Browser"), this);
 	mThumbDock->setObjectName(QStringLiteral("thumbnailDrawer"));
 	mThumbDock->setWidget(mThumbPane);
-	mThumbDock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+	mThumbDock->setAllowedAreas(Qt::LeftDockWidgetArea);
 	// Match the MFC drawer: a borderless pane with no title bar (no float/close
 	// chrome). Removing the title bar drops the move/float/close affordances
 	// while leaving the divider draggable; it is toggled with E.
 	mThumbDock->setTitleBarWidget(new QWidget(mThumbDock));
-	addDockWidget(Qt::RightDockWidgetArea, mThumbDock);
+	addDockWidget(Qt::LeftDockWidgetArea, mThumbDock);
 	mThumbDock->setVisible(false);
 	// Colour the divider between the image and the drawer to match the MFC
 	// viewer's hairline (q1theme::border) instead of Qt's default raised
@@ -2774,6 +2779,68 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event)
 	event->ignore();
 }
 
+QPointF MainWindow::viewportCenterInImage(const QSize &viewportSize) const
+{
+	if (mImage.isNull() || mScaleFactor <= 0.0) {
+		return QPointF();
+	}
+
+	const QSize content = mImageView->size();
+	const double x = content.width() <= viewportSize.width()
+		? content.width() / (2.0 * mScaleFactor)
+		: (mScrollArea->horizontalScrollBar()->value() + viewportSize.width() / 2.0) / mScaleFactor;
+	const double y = content.height() <= viewportSize.height()
+		? content.height() / (2.0 * mScaleFactor)
+		: (mScrollArea->verticalScrollBar()->value() + viewportSize.height() / 2.0) / mScaleFactor;
+	return QPointF(x, y);
+}
+
+void MainWindow::scheduleViewportSettle(const QSize &oldViewportSize)
+{
+	if (mImage.isNull() || mShowingVideo) {
+		return;
+	}
+
+	if (!mFitToWindow && !mViewportResizeAnchorValid && oldViewportSize.isValid()) {
+		mViewportResizeAnchor = viewportCenterInImage(oldViewportSize);
+		mViewportResizeAnchorValid = true;
+	}
+
+	// Restore manual transforms after this layout pass so divider dragging stays
+	// anchored. Fit mode waits for the resize burst to stop, then computes once.
+	mViewportSettleTimer->start(mFitToWindow ? 40 : 0);
+}
+
+void MainWindow::settleViewportAfterResize()
+{
+	if (mImage.isNull() || mShowingVideo) {
+		mViewportResizeAnchorValid = false;
+		return;
+	}
+
+	if (mFitToWindow) {
+		mViewportResizeAnchorValid = false;
+		updateView();
+		return;
+	}
+
+	if (!mViewportResizeAnchorValid) {
+		return;
+	}
+
+	const QSize viewport = mScrollArea->viewport()->size();
+	const QSize content = mImageView->size();
+	if (content.width() > viewport.width()) {
+		mScrollArea->horizontalScrollBar()->setValue(static_cast<int>(std::lround(
+			mViewportResizeAnchor.x() * mScaleFactor - viewport.width() / 2.0)));
+	}
+	if (content.height() > viewport.height()) {
+		mScrollArea->verticalScrollBar()->setValue(static_cast<int>(std::lround(
+			mViewportResizeAnchor.y() * mScaleFactor - viewport.height() / 2.0)));
+	}
+	mViewportResizeAnchorValid = false;
+}
+
 bool MainWindow::eventFilter(QObject *object, QEvent *event)
 {
 	// Click anywhere on the seek bar groove to jump to that frame (QSlider only
@@ -2794,13 +2861,11 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
 	}
 
 	if (event->type() == QEvent::Resize) {
-		// The viewport changes width when the window is resized or the thumbnail
-		// drawer's divider is dragged. Re-fit so the shown image tracks the
-		// available area (issue #76): the whole-window resizeEvent does not fire
-		// on a divider drag, so this is where that case is caught.
-		if (mFitToWindow && !mImage.isNull()) {
-			updateView();
-		}
+		// Drawer animation/dragging can deliver a burst of viewport resizes. Capture
+		// the pre-resize image anchor and settle once after the burst (#96), rather
+		// than fitting on every animation tick or letting manual zoom drift.
+		QResizeEvent *resize = static_cast<QResizeEvent *>(event);
+		scheduleViewportSettle(resize->oldSize());
 		if (mHelpOverlay && mHelpOverlay->isVisible()) {
 			positionHelpOverlay();
 		}
@@ -3035,9 +3100,6 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
 void MainWindow::resizeEvent(QResizeEvent *event)
 {
 	QMainWindow::resizeEvent(event);
-	if (mFitToWindow && !mImage.isNull()) {
-		updateView();
-	}
 }
 
 void MainWindow::dropEvent(QDropEvent *event)

--- a/ViewerQt/MainWindow.h
+++ b/ViewerQt/MainWindow.h
@@ -10,7 +10,9 @@
 #include <QImage>
 #include <QMainWindow>
 #include <QPoint>
+#include <QPointF>
 #include <QRect>
+#include <QSize>
 #include <QStringList>
 
 class ImageView;
@@ -180,6 +182,9 @@ private:
 	void broadcastViewState(bool force = false);
 	quint32 displayOptionBits() const;
 	void applySyncMessage(const SyncMessage &message);
+	QPointF viewportCenterInImage(const QSize &viewportSize) const;
+	void scheduleViewportSettle(const QSize &oldViewportSize);
+	void settleViewportAfterResize();
 
 protected:
 	void dragEnterEvent(QDragEnterEvent *event) override;
@@ -197,6 +202,11 @@ private:
 	QAction *mToggleDrawerAction = nullptr;
 	int mDrawerWidth = DRAWER_DEF_W;
 	QScrollArea *mScrollArea;
+	// Coalesces dock/window resize bursts. Fit is recalculated once at rest;
+	// manual zoom restores the image-space point that was under the old centre.
+	QTimer *mViewportSettleTimer;
+	QPointF mViewportResizeAnchor;
+	bool mViewportResizeAnchorValid = false;
 	// Image page = scroll area + the raw/sequence seek bar below it. The seek bar
 	// (frame slider + frame/time readout) shows only for multi-frame raw sources,
 	// mirroring the MFC viewer's bottom progress bar; video files use VideoView's

--- a/docs/STORE_LISTING.md
+++ b/docs/STORE_LISTING.md
@@ -37,7 +37,7 @@ For raw YUV sources, Viewer can show native Y, U, and V values sampled directly 
 
 Raw input can be reinterpreted quickly without reopening the file. Press N to cycle color spaces and D to cycle preset resolutions. This is useful when debugging raw YUV/RGB dumps whose format, size, or color interpretation must be checked quickly.
 
-Viewer also supports image-sequence navigation, video playback, frame/time progress display, clipboard paste, screen capture, and a resizable thumbnail browser for browsing the current folder (drag the divider to widen it for long file names without changing the window size). Open multiple Viewer windows and enable Sync Input to keep navigation, zoom, pan, rotation, playback, and display settings synchronized across them.
+Viewer also supports image-sequence navigation, video playback, frame/time progress display, clipboard paste, screen capture, and a resizable left-side thumbnail browser for browsing the current folder (drag the divider to widen it for long file names without changing the window size). Open multiple Viewer windows and enable Sync Input to keep navigation, zoom, pan, rotation, playback, and display settings synchronized across them.
 
 COMPARATOR
 
@@ -99,7 +99,7 @@ TECHNICAL NOTES
 15. Allow Different Resolution mode for cross-resolution comparisons
 16. Portable ZIP available alongside the installer
 17. Cycle raw color space (N) and preset resolutions (D) without reopening the file
-18. Resizable thumbnail drawer — drag the divider to read long file names without changing the window size
+18. Resizable left-side thumbnail drawer — drag the divider to read long file names without changing the window size
 ```
 
 ---


### PR DESCRIPTION
## Summary
- move the MFC splitter drawer to column 0 and keep the image view active in column 1
- place the Qt thumbnail dock on the left
- preserve manual zoom scale and image-space focal point across drawer toggles and divider resizing
- defer Fit-to-Window recalculation until the final settled viewport, without broadcasting transient sync states
- switch directly to the final MFC drawer layout during active video playback so 60 fps presentation cannot starve a 12-step splitter animation
- preserve the video's desktop-coordinate image origin across the direct layout switch so the subject does not jump sideways
- clear any newly exposed canvas edge, including the right-only letterbox created when the left side is clipped by the drawer
- hold the last fully composed client snapshot above the separate MFC drawer and DXGI video child surfaces until their final layout is presented, preventing striped, partially resized, or intermediate transition frames from reaching the display
- update the changelog and Store listing

## Verification
- `Viewer/Viewer.sln` Release x64 build: passed (0 warnings, 0 errors)
- `Comparator/Comparator.sln` Release x64 build: passed (0 warnings, 0 errors)
- `Tests/CoreRegressionTests.exe`: passed
- MFC still image: left drawer placement, mirrored divider drag, slide animation, manual zoom, and exact outer-window geometry verified
- First reported 1920x1080 HEVC 59.90 fps clip in a 416-file folder: old nominal 180 ms splitter animation reproduced at about 915 ms; direct-layout revision opened in 53 ms and closed in 42 ms
- Second reported `20260405_131401_main10.mp4` (1920x1080 HEVC 60.00 fps): located by filename under the real Unicode path and replayed in the Release x64 build
- Discarded the earlier automated visual result after discovering that a temporary Windows PowerShell script had mojibake-corrupted the Korean parent path and captured an incorrect-path dialog instead of the video
- Correct full-frame lossless capture then exposed a flickering striped region at the right canvas edge; clearing every exposed edge removed it
- Raw 120-poll/s capture of a 960x540 transition region (60 Hz monitor): before snapshot composition, 4-6 partially resized MFC/DXGI states were sampled; after the final fix, the capture remained on one complete pre-toggle image and changed directly to the complete final drawer layout with no striped or partial frame
- 10 rapid in-playback toggles all completed through `SendMessageTimeout`; the first took 88 ms, subsequent calls took 0.2-22.1 ms, and the window remained responsive
- Current-revision GitHub Actions is the final authority for cross-platform and packaged artifacts

Closes #96